### PR TITLE
Update es_systems.cfg

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -193,25 +193,6 @@
     </emulators>
   </system>
   <system>
-    <name>atarilynx</name>
-    <fullname>Atari Lynx</fullname>
-    <manufacturer>Atari</manufacturer>
-    <release>1989</release>
-    <hardware>portable</hardware>
-    <path>/storage/roms/atarilynx</path>
-    <extension>.lnx .LNX .zip .ZIP .7z .7Z</extension>
-    <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>atarilynx</platform>
-    <theme>atarilynx</theme>
-    <emulators>
-      <emulator name="libretro">
-        <cores>
-          <core default="true">handy</core>
-        </cores>
-      </emulator>
-    </emulators>
-  </system>
-  <system>
     <name>atarist</name>
     <fullname>Atari ST</fullname>
     <manufacturer>Atari</manufacturer>
@@ -734,8 +715,8 @@
     <emulators>
       <emulator name="libretro">
         <cores>
-          <core default="true">genesis_plus_gx</core>
-          <core>gearsystem</core>
+          <core default="true">gearsystem</core>
+          <core>genesis_plus_gx</core>
           <core>picodrive</core>
         </cores>
       </emulator>
@@ -755,8 +736,8 @@
     <emulators>
       <emulator name="libretro">
         <cores>
-          <core default="true">genesis_plus_gx</core>
-          <core>gearsystem</core>
+          <core default="true">gearsystem</core>
+          <core>genesis_plus_gx</core>
           <core>picodrive</core>
         </cores>
       </emulator>
@@ -777,6 +758,25 @@
       <emulator name="libretro">
         <cores>
           <core default="true">freeintv</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <name>atarilynx</name>
+    <fullname>Lynx</fullname>
+    <manufacturer>Atari</manufacturer>
+    <release>1989</release>
+    <hardware>portable</hardware>
+    <path>/storage/roms/atarilynx</path>
+    <extension>.lnx .LNX .zip .ZIP .7z .7Z</extension>
+    <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
+    <platform>atarilynx</platform>
+    <theme>atarilynx</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core default="true">handy</core>
         </cores>
       </emulator>
     </emulators>
@@ -1481,8 +1481,8 @@
     <emulators>
       <emulator name="libretro">
         <cores>
-          <core default="true">genesis_plus_gx</core>
-          <core>gearsystem</core>
+          <core default="true">gearsystem</core>
+          <core>genesis_plus_gx</core>
           <core>picodrive</core>
         </cores>
       </emulator>
@@ -1700,7 +1700,7 @@
     <path>/storage/roms/tg16</path>
     <extension>.pce .PCE .bin .BIN .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>pcengine</platform>
+    <platform>tg16</platform>
     <theme>tg16</theme>
     <emulators>
       <emulator name="libretro">
@@ -1720,7 +1720,7 @@
     <path>/storage/roms/tg16cd</path>
     <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>pcenginecd</platform>
+    <platform>tg16cd</platform>
     <theme>tg16cd</theme>
     <emulators>
       <emulator name="libretro">


### PR DESCRIPTION
fixed default emulator for gamegear and mastersystem from genesis_plus_dx to gearsystem (gearsystem is the correct default emulator and I had mixed it up when updating genesis)

Also updated platform for tg16 and tg16cd and fixed name Lynx name for sorting