### PR TITLE
2.0 - es_systems.cfg sorting fixes

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -465,7 +465,7 @@
     <fullname>EasyRPG</fullname>
     <manufacturer>EasyRPG</manufacturer>
     <release>2003</release>
-    <hardware>various</hardware>
+    <hardware>ports</hardware>
     <path>/storage/roms/easyrpg</path>
     <extension>.ldb</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
@@ -834,7 +834,7 @@
     <fullname>MPlayer</fullname>
     <manufacturer>MPlayer</manufacturer>
     <release>2000</release>
-    <hardware>various</hardware>
+    <hardware>ports</hardware>
     <path>/storage/roms/mplayer</path>
     <extension>.mp4 .MP4 .mkv .MKV .avi .AVI .mov .MOV .wmv .WMV .m3u .M3U .mpg .MPG .ytb .YTB .twi .TWI .sh .SH</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
@@ -1122,7 +1122,7 @@
     <fullname>OpenBOR</fullname>
     <manufacturer>OpenBOR Team</manufacturer>
     <release>2008</release>
-    <hardware>various</hardware>
+    <hardware>ports</hardware>
     <path>/storage/roms/openbor</path>
     <extension>.pak .PAK</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
@@ -1317,9 +1317,9 @@
   <system>
     <name>ports</name>
     <fullname>Ports</fullname>
-    <manufacturer>Ports</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>2020</release>
-    <hardware>port</hardware>
+    <hardware>ports</hardware>
     <path>/storage/roms/ports</path>
     <extension>.sh .SH</extension>
     <command>/usr/bin/bash %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
@@ -1867,9 +1867,9 @@
   <system>
     <name>tools</name>
     <fullname>_Tools_</fullname>
-    <manufacturer>351ELEC</manufacturer>
+    <manufacturer>Various</manufacturer>
     <release>2020</release>
-    <hardware>351elec</hardware>
+    <hardware>system</hardware>
     <path>/emuelec/scripts/modules</path>
     <extension>.sh</extension>
     <command>/usr/bin/runemu.sh %ROM% -Pshell</command>

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -1392,7 +1392,7 @@
     <name>sega32x</name>
     <fullname>Sega 32X</fullname>
     <manufacturer>Sega</manufacturer>
-    <release>1991</release>
+    <release>1994</release>
     <hardware>console</hardware>
     <path>/storage/roms/sega32x</path>
     <extension>.32x .32X .smd .SMD .bin .BIN .md .MD .zip .ZIP .7z .7Z</extension>


### PR DESCRIPTION
Updated es_systems with the following fixes to address sorting:
- Fix release year for Sega32x - Change from 1991 to 1994 for sorting
- Fix hardware and manufacturer values for easyrpg, openbor, ports and mplayer to address sorting