### PR TITLE
replace "_" with "&#xf0ad;" in the name of the Tools system

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -1866,7 +1866,7 @@
   </system>
   <system>
     <name>tools</name>
-    <fullname>_Tools_</fullname>
+    <fullname>&#xf0ad; Tools</fullname>
     <manufacturer>Various</manufacturer>
     <release>2020</release>
     <hardware>system</hardware>


### PR DESCRIPTION
this allows Tools to be sorted to the end of the list while also providing a meaningful icon to display visually