### PR TITLE
msx fixes and scraper for tg16, tg16cd, mx2

### DIFF
--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -77,7 +77,7 @@ case ${1} in
 	PLATFORM="vectrex"
 	;;
 	"msx"|"msx2")
-	PLATFORM="wonderswan"
+	PLATFORM="msx"
 	;;
 	"pcengine"|"pcenginecd"|"pcfx"|"supergrafx"|"tg16"|"tg16cd")
 	PLATFORM="pcengine"

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -1700,7 +1700,7 @@
     <path>/storage/roms/tg16</path>
     <extension>.pce .PCE .bin .BIN .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>tg16</platform>
+    <platform>pcengine</platform>
     <theme>tg16</theme>
     <emulators>
       <emulator name="libretro">
@@ -1720,7 +1720,7 @@
     <path>/storage/roms/tg16cd</path>
     <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>tg16cd</platform>
+    <platform>pcenginecd</platform>
     <theme>tg16cd</theme>
     <emulators>
       <emulator name="libretro">

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -896,7 +896,7 @@
     <release>1983</release>
     <hardware>computer</hardware>
     <path>/storage/roms/msx</path>
-    <extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z</extension>
+    <extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z .M3U .m3u</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>msx</platform>
     <theme>msx</theme>
@@ -915,9 +915,9 @@
     <release>1985</release>
     <hardware>computer</hardware>
     <path>/storage/roms/msx2</path>
-    <extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z</extension>
+    <extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z .M3U .m3u</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>msx2</platform>
+    <platform>msx</platform>
     <theme>msx2</theme>
     <emulators>
       <emulator name="libretro">


### PR DESCRIPTION
fixed platform grouping for msx in setsettings
added .m3u to extensions list for msx and msx2
fixed platform value on msx2, tg16 and tg16cd to enable scraper to function