### PR TITLE
Cleanup: Remove redundant system `megadrive-japan`

### DIFF
--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -107,7 +107,7 @@ for dir in 3do amiga amigacd32 amstradcpc arcade atari800 atari2600 atari5200 \
 	   atari7800 atarilynx atarist atomiswave BGM bios c16 c64 c128  \
 	   capcom coleco cps1 cps2 cps3 daphne daphne/roms daphne/sound \
 	   dreamcast easyrpg eduke famicom fbneo fds gameandwatch gamegear gb gba gbc \
-	   genesis intellivision mame mastersystem megadrive megadrive-japan \
+	   genesis intellivision mame mastersystem megadrive \
 	   mplayer msx msx2 n64 naomi nds neocd neogeo nes ngp ngpc odyssey openbor opt \
 	   pc pc98 pcengine pcenginecd pcfx pico-8 pokemini psp pspminis psx residualvm \
 	   residualvm/games saturn sc-3000 scummvm scummvm/games sega32x segacd sfc sg-1000 \

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -109,7 +109,7 @@ case ${1} in
 	"mastersystem")
 	PLATFORM="mastersystem"
 	;;	
-	"genesis genh"|"megadrive"|"megadrive-japan")
+	"genesis genh"|"megadrive")
 	PLATFORM="megadrive"
 	;;
 	"sega32x")

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -810,26 +810,6 @@
     </emulators>
   </system>
   <system>
-    <name>megadrive-japan</name>
-    <fullname>Mega Drive</fullname>
-    <manufacturer>Sega</manufacturer>
-    <release>1988</release>
-    <hardware>console</hardware>
-    <path>/storage/roms/megadrive-japan</path>
-    <extension>.bin .BIN .gen .GEN .md .MD .sg .SG .smd .SMD .zip .ZIP .7z .7Z</extension>
-    <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-    <platform>megadrive</platform>
-    <theme>megadrive-japan</theme>
-    <emulators>
-      <emulator name="libretro">
-        <cores>
-          <core default="true">genesis_plus_gx</core>
-          <core>picodrive</core>
-        </cores>
-      </emulator>
-    </emulators>
-  </system>
-  <system>
     <name>mplayer</name>
     <fullname>MPlayer</fullname>
     <manufacturer>MPlayer</manufacturer>


### PR DESCRIPTION
These changes remove the `megadrive-japan` system.  An identical `megadrive` system already exists with the same cores and extension configuration.  This resolves an inconsistency (for example, the NES in Japan is called Famicom, so we have `nes` and `famicom`, but we don't have `nes-europe`).