### PR TITLE
SUGGESTION: Clean up existing system names and directories

### DIFF
--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -105,9 +105,9 @@ fi
 # Create game directories if they don't exist..
 for dir in 3do amiga amigacd32 amstradcpc arcade atari800 atari2600 atari5200 \
 	   atari7800 atarilynx atarist atomiswave BGM bios c16 c64 c128  \
-	   capcom coleco cps1 cps2 cps3 daphne daphne/roms daphne/sound \
+	   capcom coleco cps cps2 cps3 daphne daphne/roms daphne/sound \
 	   dreamcast easyrpg eduke famicom fbneo fds gameandwatch gamegear gb gba gbc \
-	   genesis intellivision mame mastersystem megadrive megadrive-japan \
+	   genesis intellivision mame mastersystem megacd megadrive megadrive-japan \
 	   mplayer msx msx2 n64 naomi nds neocd neogeo nes ngp ngpc odyssey openbor opt \
 	   pc pc98 pcengine pcenginecd pcfx pico-8 pokemini psp pspminis psx residualvm \
 	   residualvm/games saturn sc-3000 scummvm scummvm/games sega32x segacd sfc sg-1000 \

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -237,7 +237,7 @@
   </system>
   <system>
     <name>cps1</name>
-    <fullname>PlaySystem</fullname>
+    <fullname>Play System</fullname>
     <manufacturer>Capcom</manufacturer>
     <release>1988</release>
     <hardware>arcade</hardware>
@@ -265,7 +265,7 @@
   </system>
   <system>
     <name>cps2</name>
-    <fullname>PlaySystem 2</fullname>
+    <fullname>Play System 2</fullname>
     <manufacturer>Capcom</manufacturer>
     <release>1993</release>
     <hardware>arcade</hardware>
@@ -293,7 +293,7 @@
   </system>
   <system>
     <name>cps3</name>
-    <fullname>PlaySystem 3</fullname>
+    <fullname>Play System 3</fullname>
     <manufacturer>Capcom</manufacturer>
     <release>1996</release>
     <hardware>arcade</hardware>

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -65,7 +65,7 @@
   </system>
   <system>
     <name>amstradcpc</name>
-    <fullname>Amstrad CPC</fullname>
+    <fullname>CPC</fullname>
     <manufacturer>Amstrad</manufacturer>
     <release>1984</release>
     <hardware>computer</hardware>
@@ -113,7 +113,7 @@
   </system>
   <system>
     <name>atari2600</name>
-    <fullname>Atari 2600</fullname>
+    <fullname>2600</fullname>
     <manufacturer>Atari</manufacturer>
     <release>1977</release>
     <hardware>console</hardware>
@@ -137,7 +137,7 @@
   </system>
   <system>
     <name>atari5200</name>
-    <fullname>Atari 5200</fullname>
+    <fullname>5200</fullname>
     <manufacturer>Atari</manufacturer>
     <release>1982</release>
     <hardware>console</hardware>
@@ -156,7 +156,7 @@
   </system>
   <system>
     <name>atari7800</name>
-    <fullname>Atari 7800</fullname>
+    <fullname>7800</fullname>
     <manufacturer>Atari</manufacturer>
     <release>1986</release>
     <hardware>console</hardware>
@@ -175,7 +175,7 @@
   </system>
   <system>
     <name>atari800</name>
-    <fullname>Atari 800</fullname>
+    <fullname>800</fullname>
     <manufacturer>Atari</manufacturer>
     <release>1979</release>
     <hardware>console</hardware>
@@ -194,7 +194,7 @@
   </system>
   <system>
     <name>atarist</name>
-    <fullname>Atari ST</fullname>
+    <fullname>ST</fullname>
     <manufacturer>Atari</manufacturer>
     <release>1985</release>
     <hardware>computer</hardware>
@@ -218,7 +218,7 @@
   </system>
   <system>
     <name>atomiswave</name>
-    <fullname>Atomiswave</fullname>
+    <fullname>Sammy Atomiswave</fullname>
     <manufacturer>Sammy</manufacturer>
     <release>2003</release>
     <hardware>arcade</hardware>
@@ -237,7 +237,7 @@
   </system>
   <system>
     <name>cps1</name>
-    <fullname>Capcom PlaySystem 1</fullname>
+    <fullname>PlaySystem</fullname>
     <manufacturer>Capcom</manufacturer>
     <release>1988</release>
     <hardware>arcade</hardware>
@@ -265,7 +265,7 @@
   </system>
   <system>
     <name>cps2</name>
-    <fullname>Capcom PlaySystem 2</fullname>
+    <fullname>PlaySystem 2</fullname>
     <manufacturer>Capcom</manufacturer>
     <release>1993</release>
     <hardware>arcade</hardware>
@@ -293,7 +293,7 @@
   </system>
   <system>
     <name>cps3</name>
-    <fullname>Capcom PlaySystem 3</fullname>
+    <fullname>PlaySystem 3</fullname>
     <manufacturer>Capcom</manufacturer>
     <release>1996</release>
     <hardware>arcade</hardware>
@@ -340,7 +340,7 @@
   </system>
   <system>
     <name>c128</name>
-    <fullname>Commodore 128</fullname>
+    <fullname>128</fullname>
     <manufacturer>Commodore</manufacturer>
     <release>1985</release>
     <hardware>computer</hardware>
@@ -359,7 +359,7 @@
   </system>
   <system>
     <name>c16</name>
-    <fullname>Commodore 16</fullname>
+    <fullname>16</fullname>
     <manufacturer>Commodore</manufacturer>
     <release>1984</release>
     <hardware>computer</hardware>
@@ -378,7 +378,7 @@
   </system>
   <system>
     <name>c64</name>
-    <fullname>Commodore 64</fullname>
+    <fullname>64</fullname>
     <manufacturer>Commodore</manufacturer>
     <release>1982</release>
     <hardware>computer</hardware>
@@ -397,7 +397,7 @@
   </system>
   <system>
     <name>vic20</name>
-    <fullname>Commodore VIC-20</fullname>
+    <fullname>VIC-20</fullname>
     <manufacturer>Commodore</manufacturer>
     <release>1980</release>
     <hardware>computer</hardware>
@@ -850,8 +850,8 @@
   </system>
   <system>
     <name>pc</name>
-    <fullname>MS-DOS</fullname>
-    <manufacturer>Microsoft</manufacturer>
+    <fullname>DOS x86</fullname>
+    <manufacturer>Microsoft/IBM/Digital Research</manufacturer>
     <release>1981</release>
     <hardware>computer</hardware>
     <path>/storage/roms/pc</path>
@@ -872,7 +872,7 @@
   </system>
   <system>
     <name>snesmsu1</name>
-    <fullname>MSU-1</fullname>
+    <fullname>Super Nintendo Entertainment System MSU-1</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>2012</release>
     <hardware>console</hardware>
@@ -892,7 +892,7 @@
   <system>
     <name>msx</name>
     <fullname>MSX</fullname>
-    <manufacturer>Microsoft</manufacturer>
+    <manufacturer>ASCII/Microsoft</manufacturer>
     <release>1983</release>
     <hardware>computer</hardware>
     <path>/storage/roms/msx</path>
@@ -911,7 +911,7 @@
   <system>
     <name>msx2</name>
     <fullname>MSX2</fullname>
-    <manufacturer>Microsoft</manufacturer>
+    <manufacturer>ASCII/Microsoft</manufacturer>
     <release>1985</release>
     <hardware>computer</hardware>
     <path>/storage/roms/msx2</path>
@@ -948,7 +948,7 @@
   </system>
   <system>
     <name>neogeo</name>
-    <fullname>Neo-Geo</fullname>
+    <fullname>Neo Geo</fullname>
     <manufacturer>SNK</manufacturer>
     <release>1990</release>
     <hardware>console</hardware>
@@ -969,7 +969,7 @@
   </system>
   <system>
     <name>neocd</name>
-    <fullname>Neo-Geo CD</fullname>
+    <fullname>Neo Geo CD</fullname>
     <manufacturer>SNK</manufacturer>
     <release>1990</release>
     <hardware>console</hardware>
@@ -989,7 +989,7 @@
   </system>
   <system>
     <name>ngp</name>
-    <fullname>Neo-Geo Pocket</fullname>
+    <fullname>Neo Geo Pocket</fullname>
     <manufacturer>SNK</manufacturer>
     <release>1998</release>
     <hardware>portable</hardware>
@@ -1008,7 +1008,7 @@
   </system>
   <system>
     <name>ngpc</name>
-    <fullname>Neo-Geo Pocket Color</fullname>
+    <fullname>Neo Geo Pocket Color</fullname>
     <manufacturer>SNK</manufacturer>
     <release>1999</release>
     <hardware>portable</hardware>
@@ -1027,7 +1027,7 @@
   </system>
   <system>
     <name>n64</name>
-    <fullname>Nintendo 64</fullname>
+    <fullname>64</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>1996</release>
     <hardware>console</hardware>
@@ -1048,7 +1048,7 @@
   </system>
   <system>
     <name>nds</name>
-    <fullname>Nintendo DS</fullname>
+    <fullname>DS</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>2005</release>
     <hardware>portable</hardware>
@@ -1158,7 +1158,7 @@
   </system>
   <system>
     <name>pcengine</name>
-    <fullname>PC-Engine</fullname>
+    <fullname>PC Engine</fullname>
     <manufacturer>NEC</manufacturer>
     <release>1987</release>
     <hardware>console</hardware>
@@ -1178,7 +1178,7 @@
   </system>
   <system>
     <name>pcenginecd</name>
-    <fullname>PC-Engine CD</fullname>
+    <fullname>PC Engine CD</fullname>
     <manufacturer>NEC</manufacturer>
     <release>1988</release>
     <hardware>console</hardware>
@@ -1229,7 +1229,7 @@
   </system>
   <system>
     <name>psx</name>
-    <fullname>Playstation</fullname>
+    <fullname>PlayStation</fullname>
     <manufacturer>Sony</manufacturer>
     <release>1994</release>
     <hardware>console</hardware>
@@ -1249,7 +1249,7 @@
   </system>
   <system>
     <name>psp</name>
-    <fullname>Playstation Portable</fullname>
+    <fullname>PlayStation Portable</fullname>
     <manufacturer>Sony</manufacturer>
     <release>2004</release>
     <hardware>portable</hardware>
@@ -1273,7 +1273,7 @@
   </system>
   <system>
     <name>pspminis</name>
-    <fullname>PSP Minis</fullname>
+    <fullname>PlayStation Portable Minis</fullname>
     <manufacturer>Sony</manufacturer>
     <release>2004</release>
     <hardware>portable</hardware>
@@ -1297,7 +1297,7 @@
   </system>
   <system>
     <name>pokemini</name>
-    <fullname>Pokemon Mini</fullname>
+    <fullname>Pokémon Mini</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>2001</release>
     <hardware>portable</hardware>
@@ -1318,7 +1318,7 @@
     <name>ports</name>
     <fullname>Ports</fullname>
     <manufacturer>Various</manufacturer>
-    <release>2020</release>
+    <release>2021</release>
     <hardware>ports</hardware>
     <path>/storage/roms/ports</path>
     <extension>.sh .SH</extension>
@@ -1411,9 +1411,29 @@
     <name>segacd</name>
     <fullname>Sega CD</fullname>
     <manufacturer>Sega</manufacturer>
-    <release>1991</release>
+    <release>1992</release>
     <hardware>console</hardware>
     <path>/storage/roms/segacd</path>
+    <extension>.chd .CHD .cue .CUE .iso .ISO .zip .ZIP .7z .7Z</extension>
+    <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
+    <platform>segacd</platform>
+    <theme>segacd</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core default="true">genesis_plus_gx</core>
+          <core>picodrive</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
+    <name>megacd</name>
+    <fullname>Mega-CD</fullname>
+    <manufacturer>Sega</manufacturer>
+    <release>1991</release>
+    <hardware>console</hardware>
+    <path>/storage/roms/megacd</path>
     <extension>.chd .CHD .cue .CUE .iso .ISO .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>segacd</platform>
@@ -1490,7 +1510,7 @@
   </system>
   <system>
     <name>megadrive</name>
-    <fullname>Sega Mega Drive</fullname>
+    <fullname>Mega Drive</fullname>
     <manufacturer>Sega</manufacturer>
     <release>1990</release>
     <hardware>console</hardware>
@@ -1510,7 +1530,7 @@
   </system>
   <system>
     <name>saturn</name>
-    <fullname>Sega Saturn</fullname>
+    <fullname>Saturn</fullname>
     <manufacturer>Sega</manufacturer>
     <release>1994</release>
     <hardware>console</hardware>
@@ -1550,7 +1570,7 @@
   </system>
   <system>
     <name>zxspectrum</name>
-    <fullname>Sinclair ZX Spectrum</fullname>
+    <fullname>ZX Spectrum</fullname>
     <manufacturer>Sinclair</manufacturer>
     <release>1982</release>
     <hardware>computer</hardware>
@@ -1569,7 +1589,7 @@
   </system>
   <system>
     <name>zx81</name>
-    <fullname>Sinclair ZX81</fullname>
+    <fullname>ZX81</fullname>
     <manufacturer>Sinclair</manufacturer>
     <release>1981</release>
     <hardware>computer</hardware>
@@ -1588,7 +1608,7 @@
   </system>
   <system>
     <name>supergrafx</name>
-    <fullname>Super Grafx</fullname>
+    <fullname>PC Engine SuperGrafx</fullname>
     <manufacturer>NEC</manufacturer>
     <release>1989</release>
     <hardware>console</hardware>
@@ -1608,7 +1628,7 @@
   </system>
   <system>
     <name>snes</name>
-    <fullname>Super Nintendo</fullname>
+    <fullname>Super Nintendo Entertainment System</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>1991</release>
     <hardware>console</hardware>
@@ -1630,7 +1650,7 @@
   </system>
   <system>
     <name>snesh</name>
-    <fullname>Super Nintendo (Hacks)</fullname>
+    <fullname>Super Nintendo Entertainment System (Hacks)</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>1991</release>
     <hardware>console</hardware>
@@ -1652,7 +1672,7 @@
   </system>
   <system>
     <name>sfc</name>
-    <fullname>Nintendo Super Famicom</fullname>
+    <fullname>Super Famicom</fullname>
     <manufacturer>Nintendo</manufacturer>
     <release>1990</release>
     <hardware>console</hardware>
@@ -1693,7 +1713,7 @@
   </system>
   <system>
     <name>tg16</name>
-    <fullname>TurboGrafx 16</fullname>
+    <fullname>TurboGrafx-16</fullname>
     <manufacturer>NEC</manufacturer>
     <release>1989</release>
     <hardware>console</hardware>
@@ -1713,7 +1733,7 @@
   </system>
   <system>
     <name>tg16cd</name>
-    <fullname>TurboGrafx 16-CD</fullname>
+    <fullname>TurboGrafx-CD</fullname>
     <manufacturer>NEC</manufacturer>
     <release>1989</release>
     <hardware>console</hardware>

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -241,7 +241,7 @@
     <manufacturer>Capcom</manufacturer>
     <release>1988</release>
     <hardware>arcade</hardware>
-    <path>/storage/roms/cps1</path>
+    <path>/storage/roms/cps</path>
     <extension>.zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>arcade</platform>


### PR DESCRIPTION
This change brings system names in line with official branding (validated against Wikipedia; I'm sure those nerds have argued over these for long enough for us to call them 'correct').  Things like 'Playstation' are now 'PlayStation', and 'PSP' is expanded to 'PlayStation Portable'.  I've removed duplication of the manufacturer name inside the `<fullname>` tag.

I think changing EmulationStation's sorting to 'Manufacturer' will bring the grouping together in a pleasing way.  I haven't tested it locally, but I have a hunch that the release date field will support exact dates, which can give us some good sorting for the regional clones (ensuring a Japanese native machine will appear before an American machine, even if they were released in the same year).

I think the only thing that might be controversial here is dropping the erroneous '1' from CPS.  Like all things that suffer from sequels, the number is never tacked on the end for the original ('PlayStation', not 'PlayStation 1', even though people online casually refer to it that way).  Wikipedia calls it 'CP System', so following my convention above the 'Capcom' belongs in the `<manufacturer>` field.  I also provide a change to its `/storage/roms` directory in `autostart.sh`.