### PR TITLE
Add Sega Mega-CD

### DIFF
--- a/packages/351elec/tmpfiles.d/351elec-dirs.conf
+++ b/packages/351elec/tmpfiles.d/351elec-dirs.conf
@@ -44,6 +44,7 @@ d    /storage/roms/genesis		0755 root root - -
 d    /storage/roms/intellivision	0755 root root - -
 d    /storage/roms/mame			0755 root root - -
 d    /storage/roms/mastersystem		0755 root root - -
+d    /storage/roms/megacd		0755 root root - -
 d    /storage/roms/megadrive		0755 root root - -
 d    /storage/roms/megadrive-japan	0755 root root - -
 d    /storage/roms/mplayer		0755 root root - -

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -1437,7 +1437,7 @@
     <extension>.chd .CHD .cue .CUE .iso .ISO .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>segacd</platform>
-    <theme>segacd</theme>
+    <theme>megacd</theme>
     <emulators>
       <emulator name="libretro">
         <cores>

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -1428,6 +1428,26 @@
     </emulators>
   </system>
   <system>
+    <name>megacd</name>
+    <fullname>Sega Mega-CD</fullname>
+    <manufacturer>Sega</manufacturer>
+    <release>1991</release>
+    <hardware>console</hardware>
+    <path>/storage/roms/megacd</path>
+    <extension>.chd .CHD .cue .CUE .iso .ISO .zip .ZIP .7z .7Z</extension>
+    <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
+    <platform>segacd</platform>
+    <theme>segacd</theme>
+    <emulators>
+      <emulator name="libretro">
+        <cores>
+          <core default="true">genesis_plus_gx</core>
+          <core>picodrive</core>
+        </cores>
+      </emulator>
+    </emulators>
+  </system>
+  <system>
     <name>genesis</name>
     <fullname>Sega Genesis</fullname>
     <manufacturer>Sega</manufacturer>


### PR DESCRIPTION
This change adds support for regional variant 'Sega Mega-CD' (Japanese 'Sega CD').