### PR TITLE
[WIP] Attempt to catch compile errors correctly.

### DIFF
--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -31,7 +31,18 @@ then
   for package in gcc retroarch pcsx_rearmed parallel-n64 uae4arm
   do
     scripts/build ${package}
+    if [ ! $? == 0 ]
+    then
+      echo "Build failed..exiting."
+      exit 1
+    fi
+    
     scripts/install ${package}
+    if [ ! $? == 0 ]
+    then
+      echo "Build failed..exiting."
+      exit 1
+    fi
   done
 fi
 


### PR DESCRIPTION
When attempting to build from a docker container the 32 bit pass failed silently, causing problems later when building the pseudo package retroarch32.

If someone can actually get the script to stop where it should on a build error that would be highly appreciated. I was unable to as is yet.