### PR TITLE
add fbneo to retroachievements supported list - round 2 =)

### DIFF
--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -136,8 +136,8 @@ case ${1} in
 	"tic80")
 	PLATFORM="tic80"
 	;;
-	"fbeno")
-	PLATFORM="fbneo"
+	"fbneo")
+	PLATFORM="arcade"
 	;;
 esac
 

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -136,6 +136,9 @@ case ${1} in
 	"tic80")
 	PLATFORM="tic80"
 	;;
+	"fbeno")
+	PLATFORM="fbneo"
+	;;
 esac
 
 	}


### PR DESCRIPTION
added the following to the group_platform function in setsettings to support retroachievements for fbneo
```
	"fbneo")
	PLATFORM="arcade"
	;;
```
