### PR TITLE
Added the new version of Carbon

### DIFF
--- a/metadata/themes.cfg
+++ b/metadata/themes.cfg
@@ -1,5 +1,6 @@
 Art-Book https://github.com/anthonycaccese/es-theme-art-book-3-2
 Handheld-Simple https://github.com/Rican7/es-theme-handheld-simple
+351ELEC-Carbon https://github.com/szalik-rg351/es-theme-351elec-carbon
 351-Noir https://github.com/MonsieurDaz/es-theme-351noir
 es-theme-switch https://github.com/Jetup13/es-theme-switch
 es-theme-epicnoir https://github.com/Jetup13/es-theme-epicnoir
@@ -7,7 +8,6 @@ es-theme-ChicueloAP https://github.com/Jetup13/es-theme-ChicueloAP
 es-theme-gbz35-mod-rg351p https://github.com/krishenriksen/es-theme-gbz35-mod-rg351p
 es-theme-solo-horizontal-arkos-ed https://github.com/Jetup13/es-theme-solo-horizontal-arkos-ed
 es-theme-minimal https://github.com/tlayne/es-theme-minimal
-es-theme-EmuELEC-carbon	https://github.com/EmuELEC/es-theme-EmuELEC-carbon
 es-theme-EmuELEC-clean-style https://github.com/EmuELEC/es-theme-EmuELEC-clean-style
 es-theme-EmuELEC-fundamental https://github.com/EmuELEC/es-theme-EmuELEC-fundamental
 es-theme-EmuELEC-Roleta https://github.com/EmuELEC/es-theme-EmuELEC-Roleta


### PR DESCRIPTION
Hello, I’ve made exclusive edit for 351ELEC. All images were optimized for the RG351 screen which improve their quality.
Logos received the same improvements too, to improve readability and consistent aesthetic.
The console and controller views were also removed.

Thanks for Jetup13 for some of his changes for ArkOs :)

Todo:for antfortytwo remove previous carbon thumb and add new one :)