### PR TITLE
2.1 - Switch to libretro's duckstation repository

### DIFF
--- a/packages/games/libretro/duckstation/package.mk
+++ b/packages/games/libretro/duckstation/package.mk
@@ -3,11 +3,11 @@
 # Maintenance 2020 351ELEC team (https://github.com/fewtarius/351ELEC)
 
 PKG_NAME="duckstation"
-PKG_VERSION="095bc280cbcd39f3bb0ceaf9ecd379f7459c65e6"
-PKG_SHA256="bbc59c4acc792c3013f9a20ad11874e94aa71ddf8159652932dd18f1b4acb4f9"
+PKG_VERSION="abb76310c4fcefb86fb72b08482c332492e70c27"
+PKG_SHA256="2b704e97226c7eb13d1f68445ac1adf2192c5b75ab3a3fe6314f5dc9ad799e40"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPLv3"
-PKG_SITE="https://github.com/stenzek/duckstation"
+PKG_SITE="https://github.com/libretro/duckstation"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain nasm:host $OPENGLES"
 PKG_SECTION="libretro"


### PR DESCRIPTION
libretro is now maintaining the duckstation core.
stenzek dropped the libretro core from his repo as of January 7, 2021.
Refer to: https://github.com/stenzek/duckstation/commit/419726f4cca2a3e054d99e374b384966713c736c

Current version: DuckStation (1.0.10-21-g1e18d9ca-dirty)
PR version: SwanStation (1.0.11-231-g8807a3ca-dirty)

Performance uplift is noticeable on Bloody Roar 2 with software rendering. Interlacing is fixed. However, this new version introduces audio distortions.