### PR TITLE
[WIP] Fix boost

### DIFF
--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -25,8 +25,8 @@ makeinstall_host() {
 }
 
 pre_configure_target() {
-  export CFLAGS="${CFLAGS} -I${SYSROOT_PREFIX}/usr/include/${PKG_PYTHON_VERSION}"
-  export CXXFLAGS="${CXXFLAGS} -I${SYSROOT_PREFIX}/usr/include/${PKG_PYTHON_VERSION}"
+  export CFLAGS="${CFLAGS} -I${TOOLCHAIN}/include/${PKG_PYTHON_VERSION}"
+  export CXXFLAGS="${CXXFLAGS} -I${TOOLCHAIN}/include/${PKG_PYTHON_VERSION}"
 }
 
 configure_target() {


### PR DESCRIPTION
Boost does not find pyconfig.h in $SYSROOT_PREFIX when building. I seem to have found it in $TOOLCHAIN instead. I am pretty sure this is not the intended behaviour.