### PR TITLE
Update controller mapping for Hypseus

### DIFF
--- a/packages/games/emulators/hypseus/patches/hypseus-003-controller.patch
+++ b/packages/games/emulators/hypseus/patches/hypseus-003-controller.patch
@@ -46,12 +46,12 @@ Signed-off-by: Laurent Merckx <laurent-merckx@skynet.be>
 +    {0, 0}, // left
 +    {0, 0}, // down
 +    {0, 0}, // right
-+    {0, 6}, // 1 player start
++    {0, 7}, // 1 player start
 +    {0, 0}, // 2 player start
 +    {0, 1}, // action button 1
 +    {0, 2}, // action button 2
 +    {0, 3}, // action button 3
-+    {0, 5}, // coin chute left
++    {0, 8}, // coin chute left
 +    {0, 0}, // coin chute right
 +    {0, 0}, // skill easy
 +    {0, 0}, // skill medium
@@ -60,8 +60,8 @@ Signed-off-by: Laurent Merckx <laurent-merckx@skynet.be>
 +    {0, 0}, // test mode
 +    {0, 0}, // reset cpu
 +    {0, 0}, // take screenshot
-+    {0, 7}, // Quit DAPHNE
-+    {0, 0}, // pause game
++    {0, 12}, // Quit DAPHNE
++    {0, 11}, // pause game
 +    {0, 0}, // toggle console (TODO)
 +    {0, 0}  // Tilt/Slam switch
 +};


### PR DESCRIPTION
I changed:
coin to "select"
start to "start"
quit to "r2" (hypseus doesn't support a key combo for this so it has to be a single button)

And added:
pause which I mapped to "l2"

I tested this change on device and here is a video showing the update in action for reference: https://drive.google.com/file/d/1-Ji6EdsDNlYnHxZSAr5AWu-5ZvqRNX_E/view?usp=sharing

---

For future reference this is the current key mapping for RG351 joypad that can be used for mapping things in Hypseus:
A = 1
B = 2
Y = 3
X = 4
L1 = 5
R1 = 6
Start = 7
Select = 8
L3 = 9
R3 = 10
L2 = 11
R2 = 12