### PR TITLE
Rgui

### DIFF
--- a/packages/351elec/sources/scripts/emustation-config
+++ b/packages/351elec/sources/scripts/emustation-config
@@ -58,7 +58,13 @@ fi
 fi 
 
 # Set audio to alsa if we are starting retroarch or default otherwise
-[[ "$1" == "retroarch" ]] && set_audio alsa || set_audio default
+# Run /usr/bin/setsettings.sh to get the lastest changes in ES before starting RetroArch as well
+if [ "$1" == "retroarch" ]; then
+  set_audio alsa
+  /usr/bin/setsettings.sh
+else
+  set_audio default
+fi
 
 TZ=$(get_ee_setting system.timezone)
 echo "TIMEZONE=$TZ" > /storage/.cache/timezone

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -252,7 +252,6 @@ log "Default settings function"
 	echo 'netplay = false' >> ${RACONF}
 	echo 'wifi_enabled = "false"' >> ${RACONF}
 	echo 'menu_driver = "xmb"' >> ${RACONF}
-	echo 'menu_linear_filter = "false"' >> ${RACONF}
 }
 
 function set_setting() {
@@ -590,14 +589,18 @@ fi
 done
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
 
-# RA menu rgui or xmb
+# RA menu rgui, ozone, glui or xmb (default)
+# menu_liner_filter is only needed for rgui
 get_setting "retroarch.menu_driver"
 if [ "${EES}" == "rgui" ]; then
 	echo 'menu_driver = "rgui"' >> ${RACONF}
 	echo 'menu_linear_filter = "true"' >> ${RACONF}
+elif [ "${EES}" == "ozone" ]; then
+	echo 'menu_driver = "ozone"' >> ${RACONF}
+elif [ "${EES}" == "glui" ]; then
+	echo 'menu_driver = "glui"' >> ${RACONF}
 else
 	echo 'menu_driver = "xmb"' >> ${RACONF}
-	echo 'menu_linear_filter = "false"' >> ${RACONF}
 fi
 
 # Show bezel if enabled

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -217,6 +217,7 @@ log "Clean settings function"
 	sed -i "/netplay_mode/d" ${RACONF}
 	sed -i "/wifi_enabled/d" ${RACONF}
 	sed -i "/menu_driver/d" ${RACONF}
+	sed -i "/menu_linear_filter/d" ${RACONF}
 }
 
 function default_settings() {
@@ -251,6 +252,7 @@ log "Default settings function"
 	echo 'netplay = false' >> ${RACONF}
 	echo 'wifi_enabled = "false"' >> ${RACONF}
 	echo 'menu_driver = "xmb"' >> ${RACONF}
+	echo 'menu_linear_filter = "false"' >> ${RACONF}
 }
 
 function set_setting() {
@@ -590,7 +592,13 @@ EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
 
 # RA menu rgui or xmb
 get_setting "retroarch.menu_driver"
-[ "${EES}" == "rgui" ] && echo 'menu_driver = "rgui"' >> ${RACONF} || echo 'menu_driver = "xmb"' >> ${RACONF}
+if [ "${EES}" == "rgui" ]; then
+	echo 'menu_driver = "rgui"' >> ${RACONF}
+	echo 'menu_linear_filter = "true"' >> ${RACONF}
+else
+	echo 'menu_driver = "xmb"' >> ${RACONF}
+	echo 'menu_linear_filter = "false"' >> ${RACONF}
+fi
 
 # Show bezel if enabled
 get_setting "bezel"

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -216,6 +216,7 @@ log "Clean settings function"
 	sed -i "/netplay_mitm_server/d" ${RACONF}
 	sed -i "/netplay_mode/d" ${RACONF}
 	sed -i "/wifi_enabled/d" ${RACONF}
+	sed -i "/menu_driver/d" ${RACONF}
 }
 
 function default_settings() {
@@ -249,6 +250,7 @@ log "Default settings function"
 	echo 'fps_show = false' >> ${RACONF}
 	echo 'netplay = false' >> ${RACONF}
 	echo 'wifi_enabled = "false"' >> ${RACONF}
+	echo 'menu_driver = "xmb"' >> ${RACONF}
 }
 
 function set_setting() {
@@ -585,7 +587,10 @@ fi
 fi
 done
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
+
+# RA menu rgui or xmb
 get_setting "retroarch.menu_driver"
+[ "${EES}" == "rgui" ] && echo 'menu_driver = "rgui"' >> ${RACONF} || echo 'menu_driver = "xmb"' >> ${RACONF}
 
 # Show bezel if enabled
 get_setting "bezel"

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="a7f6ef7ca217a381be5f14b5ace81b6a18c8e142"
+PKG_VERSION="609fcc05ac7ff88b0b3db945114c0fee45543b0d"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
The second part: This uses the [PR for EmulationStation](https://github.com/351ELEC/351elec-emulationstation/commit/609fcc05ac7ff88b0b3db945114c0fee45543b0d) and changes the RetroArch Menu Driver as set in EmulationStation. You might have to re-set your menu driver if you do not use xmb.