### PR TITLE
Revert adding epicblanchenoir

### DIFF
--- a/metadata/themes.cfg
+++ b/metadata/themes.cfg
@@ -21,5 +21,4 @@ Epic-Szalik https://github.com/szalik-rg351/Epic-Szalik
 351ELEC-Supreme https://github.com/szalik-rg351/es-theme-351elec-supreme
 351ELEC-SpinMaster https://github.com/szalik-rg351/es-theme-351elec-spin-master
 Handheld-Simple https://github.com/Rican7/es-theme-handheld-simple
-351ELEC-EpicBlancheNoir https://github.com/kefren68/es-theme-351ELEC-epicblanchenoir
 # This line will be ignored but its needed heheh


### PR DESCRIPTION
This theme simply just swap the graphics from epic-noir to be black and white without adjusting it to rg351p aspect ratio. Many systems are missing and some of them have a bad names.  This theme should be consider as a WIP, instead of adding it to package as a ready to use one