### PR TITLE
libretro-core stella-2014 and setsettings.sh cleanup to enable more achievements in retroarch

### DIFF
--- a/distributions/351ELEC/options
+++ b/distributions/351ELEC/options
@@ -303,6 +303,7 @@ snes9x2005_plus \
 snes9x2010 \
 spring \
 stella \
+stella-2014 \
 tgbdual \
 tyrquake \
 xrick \

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -12,7 +12,7 @@
 
 . /etc/profile
 
-RETROARCHIVEMENTS=(arcade atari2600 atari7800 atarilynx colecovision fbn gamegear gb gba gbc genesis mastersystem megadrive msx msx2 n64 neogeo nes ngp ngpc odyssey2 pcengine pcenginecd pokemini psx sega32x segacd sg-1000 snes tg16 tg16cd vectrex virtualboy wonderswan wonderswancolor)
+RETROARCHIVEMENTS=(arcade atari2600 atari7800 atarilynx colecovision famicom fbn fds gamegear gb gba gbah gbc gbch gbh genesis genh ggh intellivision mastersystem megacd megadrive megadrive-japan msx msx2 n64 neogeo neogeocd nes nesh ngp ngpc odyssey2 pcengine pcenginecd pcfx pokemini psx sega32x segacd sfc sg-1000 snes snesh snesmsu1 supergrafx tg16 tg16cd vectrex virtualboy wonderswan wonderswancolor)
 NOREWIND=(sega32x psx zxspectrum odyssey2 mame n64 dreamcast atomiswave naomi neogeocd saturn psp pspminis)
 NORUNAHEAD=(psp sega32x n64 dreamcast atomiswave naomi neogeocd saturn)
 
@@ -81,95 +81,101 @@ function doexit() {
   exit 0
 }
 
-function group_platform() {
-log "group platform function (${1})"
-case ${1} in 
-	"atari2600")
-	PLATFORM="atari2600"
-	;;
-	"atari7800")
-	PLATFORM="atari7800"
-	;;
-	"atarilynx")
-	PLATFORM="atarilynx"
-	;;
-	"wonderswan"|"wonderswancolor")
-	PLATFORM="wonderswan"
-	;;
-	"colecovision")
-	PLATFORM="colecovision"
-	;;
-	"vectrex")
-	PLATFORM="vectrex"
-	;;
-	"msx"|"msx2")
-	PLATFORM="msx"
-	;;
-	"pcengine"|"pcenginecd"|"pcfx"|"supergrafx"|"tg16"|"tg16cd")
-	PLATFORM="pcengine"
-	;;
-	"gb"|"gbh")
-	PLATFORM="gb"
-	;;
-	"gba"|"gbah")
-	PLATFORM="gba"
-	;;
-	"gbc"|"gbch")
-	PLATFORM="gb"
-	;;
-	"nes"|"nesh"|"fds"|"famicom")
-	PLATFORM="nes"
-	;;
-	"n64")
-	PLATFORM="n64"
-	;;
-	"pokemini")
-	PLATFORM="pokemini"
-	;;
-	"snes"|"snesh"|"snesmsu1"|"sfc")
-	PLATFORM="snes"
-	;;
-	"virtualboy")
-	PLATFORM="virtualboy"
-	;;
-	"mastersystem")
-	PLATFORM="mastersystem"
-	;;	
-	"genesis genh"|"megadrive"|"megadrive-japan")
-	PLATFORM="megadrive"
-	;;
-	"sega32x")
-	PLATFORM="sega32x"
-	;;
-	"gamegear"|"ggh")
-	PLATFORM="gamegear"
-	;;
-	"sg-1000")
-	PLATFORM="sg-1000"
-	;;
-	"segacd")
-	PLATFORM="segacd"
-	;;
-	"neogeo"|"neogeocd")
-	PLATFORM="neogeo"
-	;;
-	"ngp"|"ngpc")
-	PLATFORM="ngp"
-	;;
-	"psx")
-	PLATFORM="psx"
-	;;
-	"tic80")
-	PLATFORM="tic80"
-	;;
-	"fbn")
-	PLATFORM="arcade"
-	;;
-esac
-
-	}
-
-group_platform
+## group_platform is not used as it would group the RA savestate_directory-setting as well
+## add all the platforms directly to RETROARCHIVEMENTS 
+##
+#function group_platform() {
+#log "group platform function (${1})"
+#case ${1} in 
+#	"atari2600")
+#	PLATFORM="atari2600"
+#	;;
+#	"atari7800")
+#	PLATFORM="atari7800"
+#	;;
+#	"atarilynx")
+#	PLATFORM="atarilynx"
+#	;;
+#	"wonderswan"|"wonderswancolor")
+#	PLATFORM="wonderswan"
+#	;;
+#	"colecovision")
+#	PLATFORM="colecovision"
+#	;;
+#	"vectrex")
+#	PLATFORM="vectrex"
+#	;;
+#	"msx"|"msx2")
+#	PLATFORM="msx"
+#	;;
+#	"pcengine"|"pcenginecd"|"pcfx"|"supergrafx"|"tg16"|"tg16cd")
+#	PLATFORM="pcengine"
+#	;;
+#	"gb"|"gbh")
+#	PLATFORM="gb"
+#	;;
+#	"gba"|"gbah")
+#	PLATFORM="gba"
+#	;;
+#	"gbc"|"gbch")
+#	PLATFORM="gb"
+#	;;
+#	"nes"|"nesh"|"fds"|"famicom")
+#	PLATFORM="nes"
+#	;;
+#	"n64")
+#	PLATFORM="n64"
+#	;;
+#	"pokemini")
+#	PLATFORM="pokemini"
+#	;;
+#	"snes"|"snesh"|"snesmsu1"|"sfc")
+#	PLATFORM="snes"
+#	;;
+#	"virtualboy")
+#	PLATFORM="virtualboy"
+#	;;
+#	"mastersystem")
+#	PLATFORM="mastersystem"
+#	;;	
+#	"genesis genh"|"megadrive"|"megadrive-japan")
+#	PLATFORM="megadrive"
+#	;;
+#	"sega32x")
+#	PLATFORM="sega32x"
+#	;;
+#	"gamegear"|"ggh")
+#	PLATFORM="gamegear"
+#	;;
+#	"sg-1000")
+#	PLATFORM="sg-1000"
+#	;;
+#	"segacd"|"megacd")
+#	PLATFORM="segacd"
+#	;;
+#	"neogeo"|"neogeocd")
+#	PLATFORM="neogeo"
+#	;;
+#	"ngp"|"ngpc")
+#	PLATFORM="ngp"
+#	;;
+#	"psx")
+#	PLATFORM="psx"
+#	;;
+#	"tic80")
+#	PLATFORM="tic80"
+#	;;
+#	"fbn")
+#	PLATFORM="arcade"
+#	;;
+#       "intellivision")
+#	PLATFORM="intellivision"
+#	;;
+#esac
+#
+#	}
+#
+#group_platform 
 
 function clean_settings() {
 log "Clean settings function"

--- a/packages/games/libretro/stella-2014/package.mk
+++ b/packages/games/libretro/stella-2014/package.mk
@@ -1,0 +1,42 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="stella-2014"
+PKG_VERSION="f843da44b1828110f697bbc13142cf3b782e2f04"
+PKG_SHA256="dc42991208a18a1940ca5ba7464cec4f8c96ddb06cefa1977e87a52b58087c20"
+PKG_REV="1"
+PKG_LICENSE="GPL2"
+PKG_SITE="https://github.com/libretro/stella2014-libretro"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="Port of Stella to libretro."
+PKG_LONGDESC="Stella is a multi-platform Atari 2600 VCS emulator released under the GNU General Public License (GPL)."
+PKG_TOOLCHAIN="make"
+
+pre_configure_target() {
+PKG_MAKE_OPTS_TARGET=" -C $PKG_BUILD/ -f Makefile platform=emuelec-arm64"
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp $PKG_BUILD/stella2014_libretro.so $INSTALL/usr/lib/libretro/
+}

--- a/packages/games/libretro/stella-2014/patches/stella-2014-01-makefile.patch
+++ b/packages/games/libretro/stella-2014/patches/stella-2014-01-makefile.patch
@@ -1,0 +1,19 @@
+--- a/Makefile
++++ b/Makefile
+@@ -83,6 +83,16 @@
+ 	        fpic     += -mmacosx-version-min=10.7
+    endif
+ 
++# EmuELEC for Amlogic devices
++else ifeq ($(platform), emuelec-arm64)
++   TARGET := $(TARGET_NAME)_libretro.so
++   fpic := -fPIC
++   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
++   CXXFLAGS += -lpthread -DARM64
++   LDFLAGS += -lpthread -static-libgcc -lstdc++
++   ARCH = arm64
++   USE_DYNAREC = 1
++
+ # iOS
+ else ifneq (,$(findstring ios,$(platform)))
+    TARGET := $(TARGET_NAME)_libretro_ios.dylib

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -125,11 +125,7 @@
       <emulator name="libretro">
         <cores>
           <core default="true">stella</core>
-        </cores>
-      </emulator>
-      <emulator name="STELLASA">
-        <cores>
-          <core>STELLASA</core>
+          <core>stella2014</core>
         </cores>
       </emulator>
     </emulators>


### PR DESCRIPTION
Add libretro-core stella-2014 as the default libretro-core has sound issues with some roms and the standalone stella emulator is not included any more. 
Deactivate function "group_platform" in setsettings.sh as it does not work and add all the platforms from there to RETROARCHIVEMENTS. Add platform "megacd" and "intellivision" as well to enable achievements in retroarch.