### PR TITLE
Fall back to an older dosbox-pure commit (again)

### DIFF
--- a/packages/games/libretro/dosbox-pure/package.mk
+++ b/packages/games/libretro/dosbox-pure/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dosbox-pure"
-PKG_VERSION="05c36b14954ea87e8435a335a6b36b1e814fc775"
+PKG_VERSION="ebc294e072f98477f9ed01545bf2ae03e32fa1b5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"


### PR DESCRIPTION
This switches dosbox-pure back to an old commit (same one as in https://github.com/351ELEC/351ELEC/commit/b028bb380415eaad01d984fe0a1a178ba867654a).

The version it was updated to in https://github.com/351ELEC/351ELEC/commit/7e6d2a1bf65b7342d29561d8291ce427d99614bf did not load on my RG351V device (based on the Daily update from 4/6). Was it updated by mistake?

I tested this change by building the dosbox-pure package on my Ubuntu 20.04 box and copied it over to my RG351V device, where it now loaded properly.