### PR TITLE
Updated ScummVM Standalone emulator

### DIFF
--- a/packages/games/emulators/scummvmsa/package.mk
+++ b/packages/games/emulators/scummvmsa/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="scummvmsa"
-PKG_VERSION="e9cd6d47a510da5f2e62fbab3a85fce02276c9ba"
+PKG_VERSION="f03469a075161f67e9a7f75e29df7fffcac959d1"
 PKG_REV="1"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://github.com/scummvm/scummvm"


### PR DESCRIPTION
This update enables the standalone ScummVM emulator to play Grim Fandango and Adventure Game Studio games

It is synced with this ScummVM commit - https://github.com/scummvm/scummvm/commit/f03469a075161f67e9a7f75e29df7fffcac959d1

I tested and successfully built an image for the P/M with this change and also successfully tested booting Grim Fandango and a few AGS games on my device after updating with the generated tar.   I also confirmed that original ScummVM games continue to work as expected after this update (tested with Secret of Monkey Island)

This should be a safe change considering the testing I have done.  That said, I have no means to test the V version of the firmware and I would like another set of eyes to help check things out 😃 

Here are a few screenshots of my device playing Resonance (an AGS game) after updating
![image0](https://user-images.githubusercontent.com/1454947/114056371-968bee00-985f-11eb-9587-9c7195de47dd.jpg)
![image1](https://user-images.githubusercontent.com/1454947/114056377-97248480-985f-11eb-9e0c-96460a391c9f.jpg)
![image3](https://user-images.githubusercontent.com/1454947/114056380-97bd1b00-985f-11eb-824d-49ac999e5f7b.jpg)
![image2](https://user-images.githubusercontent.com/1454947/114056383-98ee4800-985f-11eb-8469-374c2d482730.jpg)