### PR TITLE
Update to latest EmulationStation

### DIFF
--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="9a5f26bb60d6062804f6df4034ad9f7f78cfd5d2"
+PKG_VERSION="a94abdc7eadb3181268c8a21342bc879b609677d"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
This merge will bring in the following PR from EmulationStation
https://github.com/351ELEC/351elec-emulationstation/pull/10
which adds RetroAchievements for TURBOGRAFX_CD

Tested and confirmed to build in my local build env with all up to date changes.
