### PR TITLE
040921 fixes

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -21,16 +21,7 @@ if [ -e /storage/.please_resize_me ] ; then
 
   # get the disk. /storage on 2nd partition
   PART=$(grep "/storage " /proc/mounts | cut -d" " -f1)
-
-  # get disk: /dev/sdx2 -> /dev/sdx, /dev/mmcblkxp2 -> /dev/mmcblkx
-  case ${PART} in
-    "/dev/mmcblk"*)
-      DISK=$(echo ${PART} | sed s/p2$//g)
-      ;;
-    *)
-      DISK=$(echo ${PART} | sed s/2$//g)
-      ;;
-  esac
+  DISK=$(echo ${PART} | sed s/p2$//g)
 
   rm -f /storage/.please_resize_me
   sync

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -711,14 +711,24 @@ mount_games() {
 
     for DEV in mmcblk1p1 mmcblk1 mmcblk0p3
     do
-      if [ -e "/dev/${DEV}" ]
+      if [ -e "/dev/${DEV}" ] && [ ! -e "/storage/.please_resize_me" ]
       then
-        mount /dev/${DEV} /storage/roms >/dev/null 2>&1
-        break
+	FS=$(blkid /dev/${DEV} | grep -e 'exfat' -e 'ext4' &>/dev/null)
+        if [ "$?" == "0" ]
+	then
+          mount /dev/${DEV} /storage/roms >/dev/null 2>&1
+          break
+        else
+	  echo "Unsupported games filesystem detected. Please reformat with ExFAT or EXT4."
+	  echo ""
+	  StartProgress countdown "Shutting down in 5... " 5 "NOW"
+	  sync
+	  poweroff
+	fi
       fi
     done
 
-    if [ -d "/storage/.update" ]
+    if [ -d "/storage/.update" ] && [ ! -e "/storage/.please_resize_me" ]
     then
       /usr/bin/busybox rm -rf /storage/.update >/dev/null 2>&1
       /usr/bin/busybox mkdir -p /storage/.update >/dev/null 2>&1
@@ -730,7 +740,7 @@ mount_games() {
     fi
 
     /usr/bin/busybox mountpoint -q /storage/roms >/dev/null 2>&1
-    if [ $? == "0" ]
+    if [ $? == "0" ] && [ ! -e "/storage/.please_resize_me" ]
     then
       /usr/bin/busybox mkdir -p "$UPDATE_ROOT" >/dev/null 2>&1
       mount --bind /storage/roms/update "$UPDATE_ROOT" >/dev/null 2>&1


### PR DESCRIPTION
* Stop mounting games/updates before the storage volume is resized to allow the resize to complete successfully. This corrects the issue preventing the second microsd from being installed during initial boot.
* Warn the user if they are using an unsupported filesystem and shut down to prevent operational errors.
* Tested to build and validated on a V and M.

Corrects #279