### PR TITLE
fix the advance nes config deletes snes settings

### DIFF
--- a/packages/351elec/sources/scripts/emuelec-utils
+++ b/packages/351elec/sources/scripts/emuelec-utils
@@ -130,7 +130,7 @@ EE_CONF="/storage/.config/distribution/configs/emuoptions.conf"
 	case "$1" in
 	"set")
 		PAT=$(echo "$2" | sed -e 's|\"|\\"|g' | sed -e 's|\[|\\\[|g' | sed -e 's|\]|\\\]|g')
-		sed -i "/$PAT/d" "${EE_CONF}"
+		sed -i "/^$PAT/d" "${EE_CONF}"
 		S2=${2}
 		S3=${3}
 		shift 2


### PR DESCRIPTION
Fixed: viewing/editing the advanced configuration for the NES console would delete the settings for SNES as well.