### PR TITLE
If set to AUTO in ES the RA Menu Driver will not be changed to enable…

### DIFF
--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -222,8 +222,6 @@ log "Clean settings function"
 	sed -i "/netplay_mitm_server/d" ${RACONF}
 	sed -i "/netplay_mode/d" ${RACONF}
 	sed -i "/wifi_enabled/d" ${RACONF}
-	sed -i "/menu_driver/d" ${RACONF}
-	sed -i "/menu_linear_filter/d" ${RACONF}
 }
 
 function default_settings() {
@@ -257,7 +255,6 @@ log "Default settings function"
 	echo 'fps_show = false' >> ${RACONF}
 	echo 'netplay = false' >> ${RACONF}
 	echo 'wifi_enabled = "false"' >> ${RACONF}
-	echo 'menu_driver = "xmb"' >> ${RACONF}
 }
 
 function set_setting() {
@@ -595,19 +592,28 @@ fi
 done
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
 
-# RA menu rgui, ozone, glui or xmb (default)
-# menu_liner_filter is only needed for rgui
-get_setting "retroarch.menu_driver"
-if [ "${EES}" == "rgui" ]; then
-	echo 'menu_driver = "rgui"' >> ${RACONF}
-	echo 'menu_linear_filter = "true"' >> ${RACONF}
-elif [ "${EES}" == "ozone" ]; then
-	echo 'menu_driver = "ozone"' >> ${RACONF}
-elif [ "${EES}" == "glui" ]; then
-	echo 'menu_driver = "glui"' >> ${RACONF}
-else
-	echo 'menu_driver = "xmb"' >> ${RACONF}
-fi
+# RA menu rgui, ozone, glui or xmb (fallback if everthing else fails)
+# if empty (auto in ES) do nothing to enable configuration in RA
+get_setting "retroarch.menu_driver"                                                        
+if [ "${EES}" != "false" ]; then                                                         
+        # delete setting only if we set new ones
+	# therefore configuring in RA is still possible	
+        sed -i "/menu_driver/d" ${RACONF}                                                                                                     
+        sed -i "/menu_linear_filter/d" ${RACONF}                                                                                              
+        # Set new menu driver                                                                                                   
+        if [ "${EES}" == "rgui" ]; then                                                          
+		# menu_liner_filter is only needed for rgui
+		echo 'menu_driver = "rgui"' >> ${RACONF}                                                  
+                echo 'menu_linear_filter = "true"' >> ${RACONF}                                                                               
+        elif [ "${EES}" == "ozone" ]; then                                                                 
+                echo 'menu_driver = "ozone"' >> ${RACONF}                                          
+        elif [ "${EES}" == "glui" ]; then                                                 
+                echo 'menu_driver = "glui"' >> ${RACONF}                                                                                  
+        else                                                                       
+                # play it save and set xmb if nothing else matches                                          
+                echo 'menu_driver = "xmb"' >> ${RACONF}                                                                     
+        fi                                                                      
+fi                     
 
 # Show bezel if enabled
 get_setting "bezel"


### PR DESCRIPTION
… configuration directly in RA

When retroarch menu driver is set to AUTO in ES setsettings.sh will not delete or overwrite menu_driver in /storage/.config/retroarch/retroarch.cfg any more - therefore it is possible to change this directly in RA.

To enable this mechanism the change in Emulationstation (https://github.com/351ELEC/351elec-emulationstation/pull/13) has to be live as well.
But they don't have to be in sync - as long as only one of these updates is in place the old behaviour sticks (xmb default and no changes in RA possible)
