### PR TITLE
Cleanup ES Settings/Defaults for disc-based-systems

### DIFF
--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -222,6 +222,8 @@ log "Clean settings function"
 	sed -i "/netplay_mitm_server/d" ${RACONF}
 	sed -i "/netplay_mode/d" ${RACONF}
 	sed -i "/wifi_enabled/d" ${RACONF}
+	sed -i "/menu_driver/d" ${RACONF}
+	sed -i "/menu_linear_filter/d" ${RACONF}
 }
 
 function default_settings() {
@@ -255,6 +257,7 @@ log "Default settings function"
 	echo 'fps_show = false' >> ${RACONF}
 	echo 'netplay = false' >> ${RACONF}
 	echo 'wifi_enabled = "false"' >> ${RACONF}
+	echo 'menu_driver = "xmb"' >> ${RACONF}
 }
 
 function set_setting() {
@@ -592,28 +595,19 @@ fi
 done
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
 
-# RA menu rgui, ozone, glui or xmb (fallback if everthing else fails)
-# if empty (auto in ES) do nothing to enable configuration in RA
-get_setting "retroarch.menu_driver"                                                        
-if [ "${EES}" != "false" ]; then                                                         
-        # delete setting only if we set new ones
-	# therefore configuring in RA is still possible	
-        sed -i "/menu_driver/d" ${RACONF}                                                                                                     
-        sed -i "/menu_linear_filter/d" ${RACONF}                                                                                              
-        # Set new menu driver                                                                                                   
-        if [ "${EES}" == "rgui" ]; then                                                          
-		# menu_liner_filter is only needed for rgui
-		echo 'menu_driver = "rgui"' >> ${RACONF}                                                  
-                echo 'menu_linear_filter = "true"' >> ${RACONF}                                                                               
-        elif [ "${EES}" == "ozone" ]; then                                                                 
-                echo 'menu_driver = "ozone"' >> ${RACONF}                                          
-        elif [ "${EES}" == "glui" ]; then                                                 
-                echo 'menu_driver = "glui"' >> ${RACONF}                                                                                  
-        else                                                                       
-                # play it save and set xmb if nothing else matches                                          
-                echo 'menu_driver = "xmb"' >> ${RACONF}                                                                     
-        fi                                                                      
-fi                     
+# RA menu rgui, ozone, glui or xmb (default)
+# menu_liner_filter is only needed for rgui
+get_setting "retroarch.menu_driver"
+if [ "${EES}" == "rgui" ]; then
+	echo 'menu_driver = "rgui"' >> ${RACONF}
+	echo 'menu_linear_filter = "true"' >> ${RACONF}
+elif [ "${EES}" == "ozone" ]; then
+	echo 'menu_driver = "ozone"' >> ${RACONF}
+elif [ "${EES}" == "glui" ]; then
+	echo 'menu_driver = "glui"' >> ${RACONF}
+else
+	echo 'menu_driver = "xmb"' >> ${RACONF}
+fi
 
 # Show bezel if enabled
 get_setting "bezel"

--- a/packages/351elec/sources/scripts/setsettings.sh
+++ b/packages/351elec/sources/scripts/setsettings.sh
@@ -222,8 +222,6 @@ log "Clean settings function"
 	sed -i "/netplay_mitm_server/d" ${RACONF}
 	sed -i "/netplay_mode/d" ${RACONF}
 	sed -i "/wifi_enabled/d" ${RACONF}
-	sed -i "/menu_driver/d" ${RACONF}
-	sed -i "/menu_linear_filter/d" ${RACONF}
 }
 
 function default_settings() {
@@ -257,7 +255,6 @@ log "Default settings function"
 	echo 'fps_show = false' >> ${RACONF}
 	echo 'netplay = false' >> ${RACONF}
 	echo 'wifi_enabled = "false"' >> ${RACONF}
-	echo 'menu_driver = "xmb"' >> ${RACONF}
 }
 
 function set_setting() {
@@ -595,19 +592,28 @@ fi
 done
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
 
-# RA menu rgui, ozone, glui or xmb (default)
-# menu_liner_filter is only needed for rgui
-get_setting "retroarch.menu_driver"
-if [ "${EES}" == "rgui" ]; then
-	echo 'menu_driver = "rgui"' >> ${RACONF}
-	echo 'menu_linear_filter = "true"' >> ${RACONF}
-elif [ "${EES}" == "ozone" ]; then
-	echo 'menu_driver = "ozone"' >> ${RACONF}
-elif [ "${EES}" == "glui" ]; then
-	echo 'menu_driver = "glui"' >> ${RACONF}
-else
-	echo 'menu_driver = "xmb"' >> ${RACONF}
-fi
+# RA menu rgui, ozone, glui or xmb (fallback if everthing else fails)
+# if empty (auto in ES) do nothing to enable configuration in RA
+get_setting "retroarch.menu_driver"                                                        
+if [ "${EES}" != "false" ]; then                                                         
+        # delete setting only if we set new ones
+	# therefore configuring in RA is still possible	
+        sed -i "/menu_driver/d" ${RACONF}                                                                                                     
+        sed -i "/menu_linear_filter/d" ${RACONF}                                                                                              
+        # Set new menu driver                                                                                                   
+        if [ "${EES}" == "rgui" ]; then                                                          
+		# menu_liner_filter is only needed for rgui
+		echo 'menu_driver = "rgui"' >> ${RACONF}                                                  
+                echo 'menu_linear_filter = "true"' >> ${RACONF}                                                                               
+        elif [ "${EES}" == "ozone" ]; then                                                                 
+                echo 'menu_driver = "ozone"' >> ${RACONF}                                          
+        elif [ "${EES}" == "glui" ]; then                                                 
+                echo 'menu_driver = "glui"' >> ${RACONF}                                                                                  
+        else                                                                       
+                # play it save and set xmb if nothing else matches                                          
+                echo 'menu_driver = "xmb"' >> ${RACONF}                                                                     
+        fi                                                                      
+fi                     
 
 # Show bezel if enabled
 get_setting "bezel"

--- a/packages/ui/351elec-emulationstation/config/es_settings.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_settings.cfg
@@ -66,4 +66,14 @@
 	<string name="UIMode_passkey" value="aaaba" />
 	<string name="subset.88-mph" value="on" />
 	<string name="subset.background-art" value="on" />
+	<string name="psx.HiddenExt" value="bin;img;iso" />
+	<string name="3do.HiddenExt" value="iso;bin" />
+	<string name="amigacd32.HiddenExt" value="iso" />
+	<string name="neogeocd.HiddenExt" value="iso" />
+	<string name="segacd.HiddenExt" value="iso" />
+	<string name="megacd.HiddenExt" value="iso" />
+	<string name="saturn.HiddenExt" value="iso" />
+	<string name="pcenginecd.HiddenExt" value="iso;img;bin" />
+	<string name="tg16cd.HiddenExt" value="iso;img;bin" />
+	<string name="pcfx.HiddenExt" value="toc" />
 </config>

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -6,7 +6,7 @@
     <release>1993</release>
     <hardware>console</hardware>
     <path>/storage/roms/3do</path>
-    <extension>.iso .ISO .bin .BIN .chd .CHD .cue .CUE .zip .ZIP .7z .7Z</extension>
+    <extension>.iso .ISO .bin .BIN .chd .CHD .cue .CUE</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>3do</platform>
     <theme>3do</theme>
@@ -25,7 +25,7 @@
     <release>1985</release>
     <hardware>computer</hardware>
     <path>/storage/roms/amiga</path>
-    <extension>.zip .ZIP .adf .ADF .uae .UAE .ipf .IPF .dms .DMS .adz .ADZ .lha .LHA .m3u .M3U .hdf .HDF .hdz .HDZ .m3u .M3U</extension>
+    <extension>.zip .ZIP .adf .ADF .uae .UAE .ipf .IPF .dms .DMS .adz .ADZ .lha .LHA .m3u .M3U .hdf .HDF .hdz .HDZ</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>amiga</platform>
     <theme>amiga</theme>
@@ -50,7 +50,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>/storage/roms/amigacd32</path>
-    <extension>.iso .ISO .cue .CUE .zip .ZIP .lha .LHA</extension>
+    <extension>.iso .ISO .cue .CUE .lha .LHA</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>amigacd32</platform>
     <theme>amigacd32</theme>
@@ -439,7 +439,7 @@
     <release>1998</release>
     <hardware>console</hardware>
     <path>/storage/roms/dreamcast</path>
-    <extension>.cdi .CDI .gdi .GDI .chd .CHD .zip .ZIP .7z .7Z</extension>
+    <extension>.cdi .CDI .gdi .GDI .chd .CHD .m3u .M3U</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>dreamcast</platform>
     <theme>dreamcast</theme>
@@ -966,7 +966,7 @@
     <release>1990</release>
     <hardware>console</hardware>
     <path>/storage/roms/neocd</path>
-    <extension>.cue .CUE .iso .ISO .chd .CHD .zip .ZIP .7z .7Z</extension>
+    <extension>.cue .CUE .iso .ISO .chd .CHD</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>neogeocd</platform>
     <theme>neogeocd</theme>
@@ -1175,7 +1175,7 @@
     <release>1988</release>
     <hardware>console</hardware>
     <path>/storage/roms/pcenginecd</path>
-    <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD .zip .ZIP .7z .7Z</extension>
+    <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>pcenginecd</platform>
     <theme>pce-cd</theme>
@@ -1195,7 +1195,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>/storage/roms/pcfx</path>
-    <extension>.chd .CHD .zip .ZIP .cue .CUE .ccd .CCD .toc .TOC</extension>
+    <extension>.chd .CHD .cue .CUE .ccd .CCD .toc .TOC</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>pcfx</platform>
     <theme>pcfx</theme>
@@ -1226,7 +1226,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>/storage/roms/psx</path>
-    <extension>.bin .BIN .cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO</extension>
+    <extension>.bin .BIN .cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .iso .ISO</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>psx</platform>
     <theme>psx</theme>
@@ -1404,7 +1404,7 @@
     <release>1991</release>
     <hardware>console</hardware>
     <path>/storage/roms/segacd</path>
-    <extension>.chd .CHD .cue .CUE .iso .ISO .zip .ZIP .7z .7Z</extension>
+    <extension>.chd .CHD .cue .CUE .iso .ISO</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>segacd</platform>
     <theme>segacd</theme>
@@ -1424,7 +1424,7 @@
     <release>1991</release>
     <hardware>console</hardware>
     <path>/storage/roms/megacd</path>
-    <extension>.chd .CHD .cue .CUE .iso .ISO .zip .ZIP .7z .7Z</extension>
+    <extension>.chd .CHD .cue .CUE .iso .ISO</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>segacd</platform>
     <theme>megacd</theme>
@@ -1525,7 +1525,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>/storage/roms/saturn</path>
-    <extension>.cue .CUE .chd .CHD .iso .ISO .zip .ZIP .7z .7Z</extension>
+    <extension>.cue .CUE .chd .CHD .iso .ISO</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>saturn</platform>
     <theme>saturn</theme>
@@ -1750,7 +1750,7 @@
     <release>1989</release>
     <hardware>console</hardware>
     <path>/storage/roms/tg16cd</path>
-    <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD .zip .ZIP .7z .7Z</extension>
+    <extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>pcenginecd</platform>
     <theme>tg16cd</theme>


### PR DESCRIPTION
For disc-based-systems:

* delete .zip/.7z 
* hide .iso, .bin, .img, .toc by default

**Note**: does only take effect for new installations, factory resets and if you copy over the es_settings.cfg and es_systems.cfg manually.