### PR TITLE
bump easyrpg to 0.6.2.3

### DIFF
--- a/packages/games/libretro/easyrpg/liblcf/package.mk
+++ b/packages/games/libretro/easyrpg/liblcf/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="liblcf"
-PKG_VERSION="36fccee"
+PKG_VERSION="bb9f9e2fd745d9a60a6d226eb666c259d87720aa"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/EasyRPG/liblcf"

--- a/packages/games/libretro/easyrpg/package.mk
+++ b/packages/games/libretro/easyrpg/package.mk
@@ -19,12 +19,13 @@
 ################################################################################
 
 PKG_NAME="easyrpg"
-PKG_VERSION="00ad8ab"
+PKG_VERSION="4dd00a6e1ec4b12174019f39624d268619bb3776"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/easyrpg/player"
 PKG_URL="$PKG_SITE.git"
+PKG_GIT_CLONE_BRANCH="0-6-2-stable"
 PKG_DEPENDS_TARGET="toolchain zlib liblcf pixman libspeexdsp mpg123 libsndfile libvorbis opusfile wildmidi libxmp-lite"
 PKG_PRIORITY="optional"
 PKG_SECTION="libretro"


### PR DESCRIPTION
try to fix issues some users are having with the current 0.6.1 release of easyrpg
at least it doesn't make it worse, it's perfectly running on my own device