### PR TITLE
make the es_systems.cfg in ~/.config/emulationstation optional

### DIFF
--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -40,6 +40,7 @@ makeinstall_target() {
 
 	mkdir -p $INSTALL/etc/emulationstation/
 	ln -sf /storage/.config/emulationstation/themes $INSTALL/etc/emulationstation/
+	ln -sf /usr/config/emulationstation/es_systems.cfg $INSTALL/etc/emulationstation/es_systems.cfg
 
         cp -rf $PKG_DIR/config/*.cfg $INSTALL/usr/config/emulationstation
         cp -rf $PKG_DIR/config/scripts $INSTALL/usr/config/emulationstation  


### PR DESCRIPTION
By linking the 351ELEC default file `/usr/config/emulationstation/es_systems.cfg` to `/etc/emulationstation/es_systems.cfg`  the file in the user space becomes optional and system updates to the file will be applied automatically.

Users can still have their own config-files, it is recommended to create files like `es_systems_xxx.cfg` just for the desired changes.