### PR TITLE
remove reicastsa emulator

### DIFF
--- a/packages/351elec/package.mk
+++ b/packages/351elec/package.mk
@@ -18,7 +18,7 @@ PKG_TOOLCHAIN="make"
 
 # Thanks to magicseb  Reicast SA now WORKS :D
 PKG_EXPERIMENTAL="munt quasi88 xmil np2kai hypseus"
-PKG_EMUS="$LIBRETRO_CORES advancemame PPSSPPSDL tgbdual TIC-80 pcsx_rearmed parallel-n64 fba4arm reicastsa amiberry uae4arm puae hatarisa fba4arm openbor mupen64plus mupen64plus-nx scummvmsa duckstation"
+PKG_EMUS="$LIBRETRO_CORES advancemame PPSSPPSDL tgbdual TIC-80 pcsx_rearmed parallel-n64 fba4arm amiberry uae4arm puae hatarisa fba4arm openbor mupen64plus mupen64plus-nx scummvmsa duckstation"
 PKG_TOOLS="ffmpeg libjpeg-turbo common-shaders glsl-shaders Skyscraper MC SDL_GameControllerDB linux-utils xmlstarlet CoreELEC-Debug-Scripts sixaxis jslisten evtest mpv bluetool rs97-commander-sdl2 jslisten gnupg gzip patchelf valgrind strace gdb apitrace"
 PKG_RETROPIE_DEP="bash pyudev dialog six git dbus-python pygobject coreutils"
 PKG_DEPENDS_TARGET+=" $PKG_TOOLS $PKG_RETROPIE_DEP $PKG_EMUS $PKG_EXPERIMENTAL ports moonlight"

--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -449,9 +449,6 @@
           <core default="true">flycast</core>
         </cores>
       </emulator>
-      <emulator name="REICAST">
-        <cores></cores>
-      </emulator>
     </emulators>
   </system>
   <system>

--- a/scripts/update_packages
+++ b/scripts/update_packages
@@ -6,7 +6,7 @@
 
 OPTIONS="distributions/351ELEC/options"
 RAPACKAGES="retroarch retroarch-assets retroarch-joypad-autoconfig retroarch-overlays libretro-database core-info glsl-shaders"
-EMUPACKAGES="$LIBRETRO_CORES advancemame PPSSPPSDL tgbdual TIC-80 pcsx_rearmed parallel-n64 fba4arm reicastsa amiberry uae4arm puae hatarisa fba4arm openbor mupen64plus mupen64plus-nx scummvmsa duckstation"
+EMUPACKAGES="$LIBRETRO_CORES advancemame PPSSPPSDL tgbdual TIC-80 pcsx_rearmed parallel-n64 fba4arm amiberry uae4arm puae hatarisa fba4arm openbor mupen64plus mupen64plus-nx scummvmsa duckstation"
 BLOCKLIST="config/blocklist"
 
 source "${OPTIONS}"


### PR DESCRIPTION
Seems this emulator never worked?
I can't even find it on our current image.