### PR TITLE
Do not create new es_systems.cfg in /storage/.emulationstation/ and r…

### DIFF
--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -231,12 +231,16 @@ fi
 # Migrate old emuoptions.conf if it exist
 if [ -e "/storage/.config/distribution/configs/emuoptions.conf" ]
 then
-  echo "Found old config - merging"
   echo "# -------------------------------" >> /storage/.config/distribution/configs/distribution.conf
   cat /storage/.config/distribution/configs/emuoptions.conf >> /storage/.config/distribution/configs/distribution.conf
   echo "# -------------------------------" >> /storage/.config/distribution/configs/distribution.conf
-  echo "Move to backupfile"
   mv /storage/.config/distribution/configs/emuoptions.conf /storage/.config/distribution/configs/emuoptions.conf.bak
+fi
+
+# Save old es_systems.cfg in case it is still needed
+if [ -f /storage/.config/emulationstation/es_systems.cfg ]; then
+        mv /storage/.config/emulationstation/es_systems.cfg\
+           /storage/.config/emulationstation/es_systems.oldcfg-rename-to:es_systems_custom.cfg-if-needed
 fi
 
 sync &

--- a/packages/351elec/sources/scripts/emustation-config
+++ b/packages/351elec/sources/scripts/emustation-config
@@ -102,7 +102,8 @@ if [ "$EE_DEVICE" == "OdroidGoAdvance" ] || [[ "$EE_DEVICE" =~ RG351 ]]; then
 fi
 
 if [[ ! -f "/storage/.newcfg" ]]; then
-  cp -f "/usr/config/emulationstation/es_systems.cfg" "/storage/.config/emulationstation/es_systems.cfg"
+  # we don't use es_systems.cfg in this folder anymore
+  # cp -f "/usr/config/emulationstation/es_systems.cfg" "/storage/.config/emulationstation/es_systems.cfg"
   touch /storage/.newcfg
   echo -en '\e[20;0H                                        ' >/dev/console
 fi

--- a/packages/sysutils/systemd/scripts/userconfig-setup
+++ b/packages/sysutils/systemd/scripts/userconfig-setup
@@ -11,6 +11,8 @@ done
 if [ ! -e "/storage/.configured" ]
 then
   # Copy config files, but don't overwrite.  Only run if /storage is fresh
-  cp -iRp /usr/config/* /storage/.config/ &>/dev/null
+  ## cp -iRp /usr/config/* /storage/.config/ &>/dev/null
+  ## ignore es_systems.cfg and switch to rsync
+  rsync -a --ignore-existing --exclude=es_systems.cfg /usr/config/* /storage/.config/
   touch /storage/.configured
 fi


### PR DESCRIPTION
…ename exisiting file

- [x] rename `es_systems.cfg` to `es_systems.oldcfg-rename-to:es_systems_custom.cfg-if-needed` if it exists
- [x] Do not place `es_systems.cfg` in `/storage/.emulationstation/` on Factory Reset or New Install
- [x] Backup Identity does not include `es_systems.cfg` nothing to do here
- [x] Backup already stores `es_*.cfg` therefore custom files will be included - nothing to do here