### PR TITLE
RA uses correct TZ

### DIFF
--- a/packages/351elec/sources/scripts/emustation-config
+++ b/packages/351elec/sources/scripts/emustation-config
@@ -67,7 +67,7 @@ else
 fi
 
 TZ=$(get_ee_setting system.timezone)
-echo "TIMEZONE=$TZ" > /storage/.cache/timezone
+echo -n "TIMEZONE=$TZ" > /storage/.cache/timezone
 systemctl restart tz-data.service
 
 # create charmap used for translations


### PR DESCRIPTION
RA reads the file `/storage/.cache/timezone` and does not like CRs at the end. Fixed by writing none.