### PR TITLE
bump vexc and dosbox-pure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILD_DIRS=build.*
 
-all: clean world
+all:
 
 system:
 	./scripts/image

--- a/config/blocklist
+++ b/config/blocklist
@@ -1,2 +1,1 @@
 retroarch-joypad-autoconfig
-dosbox-pure

--- a/config/blocklist
+++ b/config/blocklist
@@ -1,5 +1,2 @@
 retroarch-joypad-autoconfig
-vecx
-pcsx_rearmed
 dosbox-pure
-easyrpg

--- a/packages/games/libretro/dosbox-pure/package.mk
+++ b/packages/games/libretro/dosbox-pure/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dosbox-pure"
-PKG_VERSION="ebc294e072f98477f9ed01545bf2ae03e32fa1b5"
+PKG_VERSION="d0e6234d3a378311d26f9deffee4a9636e589aeb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
@@ -36,7 +36,7 @@ PKG_AUTORECONF="no"
 PKG_TOOLCHAIN="make"
 
 make_target() {
-  make
+  make platform=emuelec-hh
 }
 
 makeinstall_target() {

--- a/packages/games/libretro/dosbox-pure/patches/dosbox-pure-add-emuelec-platform.patch
+++ b/packages/games/libretro/dosbox-pure/patches/dosbox-pure-add-emuelec-platform.patch
@@ -1,0 +1,33 @@
+--- a/Makefile
++++ b/Makefile
+@@ -88,6 +88,30 @@
+ LDFLAGS += $(CPUFLAGS) -lpthread -shared
+ #LDFLAGS += -static-libstdc++ -static-libgcc #adds 1MB to output
+ 
++ifneq (,$(findstring emuelec,$(platform)))
++OUTNAME := dosbox_pure_libretro.so
++BUILD    := RELEASE
++BUILDDIR := release
++CFLAGS   := -DNDEBUG -O3 -fno-ident
++LDFLAGS  += -O3 -fno-ident
++
++CPUFLAGS := -mtune=cortex-a53 -mcpu=cortex-a53 -march=armv8-a+crc+fp+simd
++   
++ ifneq (,$(findstring emuelec-hh,$(platform)))
++   CPUFLAGS := -mtune=cortex-a35 -mcpu=cortex-a35 -march=armv8-a+crc+fp+simd
++ endif
++ ifneq (,$(findstring emuelec-ng,$(platform)))
++   CPUFLAGS := -mtune=cortex-a72.cortex-a53 -mcpu=cortex-a72.cortex-a53 -march=armv8-a+crc+fp+simd
++ endif
++
++CFLAGS  += $(CPUFLAGS) -fpic -fomit-frame-pointer -fno-exceptions -fno-non-call-exceptions -Wno-psabi -Wno-format
++LDFLAGS += $(CPUFLAGS) -lpthread -Wl,--gc-sections -shared
++CXX = $(CC)
++endif
++
++CFLAGS  += -pthread -D__LIBRETRO__ -Iinclude
++$(info Building $(platform) with $(CPUFLAGS))
++
+ .PHONY: all clean
+ all: $(OUTNAME)
+ 

--- a/packages/games/libretro/vecx/package.mk
+++ b/packages/games/libretro/vecx/package.mk
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="vecx"
-PKG_VERSION="e572e5e52ed41cf5ac5bfed99a7e1351fb31ce55"
-PKG_SHA256="1e33b190c2529f92f1a2806e5e6b3f74b1f1ab635d2fc7f9dbe9713a6f8f828c"
+PKG_VERSION="0f3f04b0e5bbb484a84e3416d07f0ae8cdac386e"
+PKG_SHA256="068b809165b5ccfc8742d7ee548caf52a878729ba4731a559b1132e51eb65aa0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2|LGPLv2.1"

--- a/packages/games/libretro/vecx/package.mk
+++ b/packages/games/libretro/vecx/package.mk
@@ -26,7 +26,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPLv2|LGPLv2.1"
 PKG_SITE="https://github.com/libretro/libretro-vecx"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain ${OPENGLES}"
+PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="libretro"
 PKG_SHORTDESC="libretro adaptation of vecx"
@@ -37,7 +37,7 @@ PKG_TOOLCHAIN="make"
 PKG_AUTORECONF="no"
 
 make_target() {
-  make -f Makefile.libretro
+  make -f Makefile.libretro HAS_GPU=1 HAS_GLES=1
 }
 
 makeinstall_target() {


### PR DESCRIPTION
This PR fixes the build of vexc and dosbox-pure
Also removes make all chain to prevent accidental deletion of build folders.