### PR TITLE
FIX: add boost to poppler's dependencies

### DIFF
--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -55,6 +55,7 @@ PKG_CONFIGURE_OPTS_TARGET="py_cv_mod_gtk_=yes \
                            --disable-nls"
 
 pre_configure_target() {
+  pwd
   NOCONFIGURE=1 ./autogen.sh
 }
 


### PR DESCRIPTION
This fixes this build error:

    In file included from ../splash/Splash.cc:49:
    ../splash/SplashXPathScanner.h:31:14: fatal error: boost/container/small_vector.hpp: No such file or directory
    31 | #    include <boost/container/small_vector.hpp>