### PR TITLE
FIX: add boost to poppler's dependencies 

### DIFF
--- a/packages/print/poppler/package.mk
+++ b/packages/print/poppler/package.mk
@@ -9,7 +9,7 @@ PKG_SHA256="01575e4c1510c657839e742cfeabdcbd8d99dd9e9cc3dff74748643a3e7ab7d9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/freedesktop/poppler"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain zlib libpng libjpeg-turbo"
+PKG_DEPENDS_TARGET="toolchain zlib libpng libjpeg-turbo boost"
 PKG_LONGDESC="This is Poppler, a library for rendering PDF files, and examining or modifying their structure."
 PKG_TOOLCHAIN="cmake"
 


### PR DESCRIPTION
This fixes this error 'fatal error: boost/container/small_vector.hpp: No such file or directory'.