### PR TITLE
Add 4:3 version of es-theme-art-book for RG351V

### DIFF
--- a/metadata/RG351V/themes.cfg
+++ b/metadata/RG351V/themes.cfg
@@ -5,5 +5,6 @@ GBZ https://github.com/szalik-rg351/351elec-rg351v-gbz
 Cody-Destroy https://github.com/szalik-rg351/351elec-rg351v-cody-destroy
 Kiwi https://github.com/szalik-rg351/ES-Theme-Dark-Kiwimod-RG351-1
 Art-Book https://github.com/anthonycaccese/es-theme-art-book-3-2
+Art-Book-4-3 https://github.com/solarized-dark/es-theme-art-book-4-3
 Handheld-Simple https://github.com/Rican7/es-theme-handheld-simple
 # This line will be ignored but its needed heheh


### PR DESCRIPTION
Adds a 4:3 version of es-theme-art-book-3-2 originally by @anthonycaccese.

The only changes are:

- Changed image ratio for display on 3:2 display
- Tweaked font sizes (slightly smaller) for slightly more stuff shown

Happy to relinquish the repo if @anthonycaccese has interest in taking over, but otherwise I also don't mind maintaining it. I've tested the theme in both 351ELEC and ArkOS, for what it's worth, and it works well in both.