### PR TITLE
Add support for Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build.*
+sources
+release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04
+
+RUN apt-get update  \
+    && DEBIAN_FRONTEND=noninteractive \
+      apt-get install -y \
+      gcc make git unzip wget \
+      xz-utils libsdl2-dev libsdl2-mixer-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev \
+      rapidjson-dev libasound2-dev libgl1-mesa-dev build-essential libboost-all-dev cmake fonts-droid-fallback \
+      libvlc-dev libvlccore-dev vlc-bin texinfo premake4 golang libssl-dev curl patchelf \
+      xmlstarlet patchutils gawk gperf xfonts-utils default-jre python xsltproc libjson-perl \
+      lzop libncurses5-dev device-tree-compiler u-boot-tools rsync p7zip unrar libparse-yapp-perl \
+      zip binutils-aarch64-linux-gnu dos2unix bsdmainutils bc \
+      && apt-get autoremove --purge -y \
+      && apt-get clean -y \
+      && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --disabled-password --gecos '' docker
+
+RUN mkdir -p /work && chown docker /work
+
+WORKDIR /work
+USER docker

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,38 @@ v-aarch64:
 
 update:
 	DEVICE=RG351P ARCH=aarch64 ./scripts/update_packages
+
+
+## Docker builds - overview
+# docker-* commands just wire up docker to call the normal make command via docker
+# For example: make docker-RG351V will use docker to call: make RG351V
+# All variables are scoped to docker-* commands to prevent weird collisions/behavior with non-docker commands
+
+docker-%: DOCKER_IMAGE := "351build/351elec-build:latest"
+
+# UID is the user ID of current user - ensures docker sets file permissions properly
+docker-%: UID := $(shell id -u)
+
+# GID is the main user group of current user - ensures docker sets file permissions properly
+docker-%: GID := $(shell id -g)
+
+# PWD is 'present working directory' and passes through the full path to current dir to docker (becomes 'work')
+docker-%: PWD := $(shell pwd)
+
+# Use 'sudo' if docker ps doesn't work.  In theory, other things than missing sudo could cause this.  But sudo needed is a common issue and easy to fix.
+docker-%: SUDO := $(shell if ! docker ps -q 2>&1 > /dev/null; then echo "sudo"; fi)
+
+# Launch docker as interactive if this is an interactive shell (allows ctrl-c for manual and running non-interactive - aka: build server)
+docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")
+
+# Command: builds docker image locally from Dockerfile
+docker-image-build:
+	$(SUDO) docker build . -t $(DOCKER_IMAGE)
+# Command: pulls latest docker image from dockerhub.  This will *replace* locally built version.
+docker-image-pull:
+	$(SUDO) docker pull $(DOCKER_IMAGE)
+
+# Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
+docker-%:
+	$(SUDO) docker run $(INTERACTIVE) --rm --user $(UID):$(GID) -v $(PWD):/work $(DOCKER_IMAGE) make $*
+

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ It will build for both the RG351P/M and for the RG351V.
 
 To create the image for the RG351P/M just ``make RG351P``, and just for the RG351V ``make RG351V``.
 
+## Building from Source - Docker
+Building with Docker simplifies the build process as any dependencies, with the exception of `make`, are contained within the docker image - all CPU/RAM/Disk/build time requirements remain similar. 
+
+NOTE: Make can be installed with `sudo apt update && sudo apt install -y make` on Ubuntu-based systems.
+
+All make commands are available via docker, by prepending `docker-`. `make RG351V` becomes `make docker-RG351V` and `make clean` becomes `make docker-clean`.
+
+New docker make commands: 
+- `make docker-image-build` - Builds the docker image based on the Dockerfile.  This is not required unless changes are needed locally. 
+- `make docker-image-pull` - Pulls docker image from dockerhub.  This will update to the latest image and replace any locally built changes to the docker file.
+
+Example building with docker:
+```
+git clone https://github.com/351ELEC/351ELEC.git 351ELEC  
+cd 351ELEC
+make docker-clean
+make docker-world
+```
+
 ## License
 
 351ELEC is a fork of EmuELEC which is based on CoreELEC which in turn is licensed under the GPLv2 (and GPLv2-or-later), all original files created by the 351ELEC team are licensed as GPLv2-or-later and marked as such.


### PR DESCRIPTION
# Summary
Building with Docker simplifies the build process as any dependencies are contained within the Docker image.  In order to make docker builds easy to use and keep automation in the project unified, I've updated the Makefile to help building via docker.  This would mean more or less any system with make installed (technically `gmake`) and Docker along with a few system utilities (`id`, `pwd`) would be able to build 351ELEC.

All make commands are available via docker, by prepending `docker-`. For example, `make RG351V` becomes `make docker-RG351V` and `make clean` becomes `make docker-clean`.  This enables existing and new commands added to the Makefile to be easily used via docker without affecting existing behavior.  Credit to the batocera team for the idea of how this could work: (https://github.com/batocera-linux/batocera.linux/pull/1434/files) and @dhwz  for pointing out their Docker integration.

## New docker make commands:                                                                            
- `make docker-image-build` - Builds the docker image based on the Dockerfile.  This is not required unless changes are needed locally.
- `make docker-image-pull` - Pulls docker image from dockerhub.  This will update to the latest image and replace any locally built changes to the docker file.

Example building with docker:
```
git clone https://github.com/351ELEC/351ELEC.git 351ELEC  

cd 351ELEC
make docker-image-pull  # not required - but will ensure the latest image is pulled in
make docker-clean
make docker-world
```

## Notes on Docker installation
- It is recommended to use the Docker installation process from Docker itself as opposed to distribution specific process (for example, don't use: `apt install docker.io`).  You should use: https://docs.docker.com/engine/install/.  This is mainly to avoid really old versions of docker (ubuntu 16.04/18.04) and WSL2 doesn't work properly with `docker.io` even in Ubuntu 20.04

## Thoughts on caching the toolchain (future)
By standardizing the build environment into Docker, it would be possible to cache/share build artifacts (such as the toolchain) in the future to improve build times, but this is not currently done.  I'm not sure the exact right way to do this, so excluding this change for now as (I think) it would require some updates to the Makefile to do right.

One idea  would be if we built the toolchain in the docker build and then stored the toolchain in another standard directory (/opt/toolchain/aarch64, etc), the Makefile could be updated to populate the build* directories from the /opt/toolchain if the toolchain didn't exist, etc.  I'm also not sure if only the `toolchain` directory is needed to be saved or the other dependent packages too (FYI: I saw some errors with `libltdl` which I think is part of `libtool` that indicate just the `toolchain` directory may not be enough.)
