### PR TITLE
Add docker-image-push and correct dockerhub organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ update:
 # For example: make docker-RG351V will use docker to call: make RG351V
 # All variables are scoped to docker-* commands to prevent weird collisions/behavior with non-docker commands
 
-docker-%: DOCKER_IMAGE := "351build/351elec-build:latest"
+docker-%: DOCKER_IMAGE := "351elec/351elec-build:latest"
 
 # UID is the user ID of current user - ensures docker sets file permissions properly
 docker-%: UID := $(shell id -u)
@@ -73,6 +73,13 @@ docker-image-build:
 # Command: pulls latest docker image from dockerhub.  This will *replace* locally built version.
 docker-image-pull:
 	$(SUDO) docker pull $(DOCKER_IMAGE)
+
+# Command: pushes the latest Docker image to dockerhub.  This is *not* needed to build. It updates the latest build image in dockerhub for everyone.
+# Only 351elec admins in dockerhub can do this.
+#
+# You must login with: docker login --username <username> and provide either a password or token (from user settings -> security in dockerhub) before this will work.
+docker-image-push:
+	$(SUDO) docker push $(DOCKER_IMAGE)
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:


### PR DESCRIPTION
# Summary
Use the 351elec dockerhub organization to match our github instead of a '351build' dockerhub user.  Using an organization also allows having @Cebion and others as an admin on dockerhub in case I get hit by a bus, etc.

This should have no impact on those running builds and only sets up better administration of the docker build image.

# Details
- Adds a new make command to push the docker image. `make docker-image-push`.  This makes it easy for Cebion/myself/others with access to dockerhub to push the docker image until we get automated builds setup.  This push command only needs to be done when the Dockerfile changes.
- Once we connect 351ELEC/351ELEC github to the dockerhub 351elec organization (a github admin of the 351ELEC, such as Cebion, would need to do this) and setup automated builds, the manual push step is not needed.