### PR TITLE
GBA: change gpsp to be 32bit and use platform=armv

### DIFF
--- a/packages/351elec/sources/scripts/runemu.sh
+++ b/packages/351elec/sources/scripts/runemu.sh
@@ -340,7 +340,7 @@ else
 
 	### Check if we need retroarch 32 bits or 64 bits
 	RABIN="retroarch"
-	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]] || [[ "${CORE}" =~ "uae4arm" ]]
+	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]] || [[ "${CORE}" =~ "uae4arm" ]] || [[ "${CORE}" =~ "gpsp" ]]
 	then
 		if [ "${MYARCH}" == "arm" ]
 		then

--- a/packages/games/libretro/gpsp/package.mk
+++ b/packages/games/libretro/gpsp/package.mk
@@ -32,6 +32,7 @@ PKG_PRIORITY="optional"
 PKG_SECTION="libretro"
 PKG_SHORTDESC="gpSP for libretro."
 PKG_LONGDESC="gameplaySP is a Gameboy Advance emulator for Playstation Portable"
+VERSION=${LIBREELEC_VERSION}
 
 PKG_IS_ADDON="no"
 PKG_TOOLCHAIN="make"
@@ -39,7 +40,7 @@ PKG_AUTORECONF="no"
 
 make_target() {
   if [ "$ARCH" == "arm" ]; then
-    make CC=$CC platform=unix
+    make CC=$CC platform=armv
   else
     make CC=$CC
   fi  
@@ -47,5 +48,9 @@ make_target() {
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
-  cp gpsp_libretro.so $INSTALL/usr/lib/libretro/
+  if [ "${ARCH}" != "aarch64" ]; then
+    cp gpsp_libretro.so $INSTALL/usr/lib/libretro/
+  else
+    cp -vP $PKG_BUILD/../../build.${DISTRO}-${DEVICE}.arm-${VERSION}/gpsp-*/.install_pkg/usr/lib/libretro/gpsp_libretro.so $INSTALL/usr/lib/libretro/
+  fi
 }

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -10,7 +10,7 @@ echo using core: "$1"
 echo platform: "$3"
 echo starting game... "$2"
 sleep 1
-if [[ "$1" =~ "pcsx_rearmed" ]] || [[ "$1" =~ "parallel_n64" ]] || [[ "$1" =~ "uae4arm" ]]
+if [[ "$1" =~ "pcsx_rearmed" ]] || [[ "$1" =~ "parallel_n64" ]] || [[ "$1" =~ "uae4arm" ]] || [[ "$1" =~ "gpsp" ]]
 then
   export LD_LIBRARY_PATH="/usr/lib32"
   /usr/bin/retrorun32 --triggers -n -s /storage/roms/"$3" -d /roms/bios "$1" "$2"

--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -34,7 +34,7 @@ elif [ "${ARCH}" == "arm" ]
 then
   # Only build the 32bit packages that we need rather than the whole image
   # to speed up the build process and save disk space.
-  for package in gcc retroarch retrorun pcsx_rearmed parallel-n64 parallel-n64_gln64 uae4arm
+  for package in gcc retroarch retrorun gpsp pcsx_rearmed parallel-n64 parallel-n64_gln64 uae4arm
   do
     scripts/build ${package}
     if [ ! $? == 0 ]


### PR DESCRIPTION
This fixes Final Fantasy 6  graphical glitches in the intro (and probably other games) and makes the game run better than the other emulators on the system

Before:
![Final Fantasy VI Advance (USA)-210529-214410](https://user-images.githubusercontent.com/407195/120086788-ea85b700-c0d9-11eb-90e6-74fbe3c7c7ea.png)
After:
![Final Fantasy VI Advance (USA)-210529-212547](https://user-images.githubusercontent.com/407195/120086794-f96c6980-c0d9-11eb-8112-dd2fb717b75d.png)

Before:
![Final Fantasy VI Advance (USA)-210529-214426](https://user-images.githubusercontent.com/407195/120086789-f07b9800-c0d9-11eb-8219-e33677c2576e.png)
After:
![Final Fantasy VI Advance (USA)-210529-212608](https://user-images.githubusercontent.com/407195/120086797-fb362d00-c0d9-11eb-8bd6-6d73ecc1fb78.png)

Tested both on the RG351V and RG351P
