### PR TITLE
Fix issue with using the PR head commit

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -35,8 +35,6 @@ jobs:
         with:
           # clean: false ensures that we don't remove all the build files 
           clean: false
-          # pull requests require explicitly using the pr sha
-          ref: ${{ github.event.pull_request.head.sha }}
       
       - name: Get date for artifacts
         id: date


### PR DESCRIPTION
# Summary
The way the PR build code works, it checks out the PR branch as is and builds it.  This is normally fine.  However, if someone submits a PR from an old commit, it will build the project with all the old stuff.  

Even that is not usually a problem, however, with the .ccache change as it will cause a ton of extra disk usage (.ccache folder at project root vs in build directories) which could cause the build server to run out of disk space.

Instead what should be done is the *merge* of the current main and the PR should be built (this will be exactly the build once the change is merged into `main`).  This is actually what github actions does by default, so the fix is easy.

# Fix 
Just don't try and be fancy with what commit to build and let the PR checkout work correctly.

