### PR TITLE
Docker-Build: Switch /work to $(pwd) add `docker-shell` option

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -32,11 +32,11 @@ jobs:
       - name: Build rg351P
         run: |
             set -e
-            make docker-RG351P
+            make DOCKER_WORK_DIR=/work docker-RG351P
       - name: Build rg351V
         run: |
             set -e
-            make docker-RG351V
+            make DOCKER_WORK_DIR=/work docker-RG351V
       - name: Cleanup system artifacts
         run: |
             set -e

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -47,11 +47,11 @@ jobs:
       - name: Build rg351P
         run: |
             set -e
-            make docker-RG351P
+            make DOCKER_WORK_DIR=/work docker-RG351P
       - name: Build rg351V
         run: |
             set -e
-            make docker-RG351V
+            make DOCKER_WORK_DIR=/work docker-RG351V
       - name: Cleanup system artifacts (no .img in PR builds)
         run: |
             set -e

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ update:
 
 docker-%: DOCKER_IMAGE := "351elec/351elec-build:latest"
 
+# DOCKER_WORK_DIR is the directory in the Docker image - it used to be /work
+#   Anytime this directory changes, you must run `make clean` similarly to moving the 351ELEC directory
+docker-%: DOCKER_WORK_DIR := $(shell if [ -n "${DOCKER_WORK_DIR}" ]; then echo ${DOCKER_WORK_DIR}; else echo $$(pwd); fi)
+
 # UID is the user ID of current user - ensures docker sets file permissions properly
 docker-%: UID := $(shell id -u)
 
@@ -90,4 +94,4 @@ docker-image-push:
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:
-	$(SUDO) docker run $(INTERACTIVE) --rm --user $(UID):$(GID) -v $(PWD):/work $(DOCKER_IMAGE) $(COMMAND)
+	$(SUDO) docker run $(INTERACTIVE) --rm --user $(UID):$(GID) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ All make commands are available via docker, by prepending `docker-`. `make RG351
 New docker make commands: 
 - `make docker-image-build` - Builds the docker image based on the Dockerfile.  This is not required unless changes are needed locally. 
 - `make docker-image-pull` - Pulls docker image from dockerhub.  This will update to the latest image and replace any locally built changes to the docker file.
+- `make docker-shell` - (advanced) Launches a shell inside the docker build container.  This allows running any development commands like `./scripts/build`, etc, which aren't in the Makefile.
+  - NOTE: Errors like `groups: cannot find name for group ID 1002` and the user being listed as `I have no name!` are OK and a result of mapping the host user/group into the docker container where the host user/groups may not exist.
 
 Example building with docker:
 ```


### PR DESCRIPTION
## Background
The docker build currently sets the current directory as `/work` inside the container.  This means you cannot run commands from the host (`./scripts/build`, etc) if you have the same version of build tools on your host (ubuntu 20.04) because `/work` will get encoded into many packages/artifacts/etc.  This is kind of a pain if you have Ubuntu 20.04 as a host and are also using docker to build as you cannot easily switch between the two.

Additionally, if you *don't* have build tools on your host (or are running Debian / CentOS / Ubuntu 18.04 etc) and versions of build tools don't match), there's no way to run commands other than `make` (such as `./scripts/build`) with docker.

## Features
- Switch docker to use `pwd` (current directory) by default, causing the directory to match the host.
  - IMPORTANT: This will require a `make clean` for any devs using `docker-*` commands
    - If you would like to continue using `/work`, you can use `DOCKER_WORK_DIR`.  Ex: `export DOCKER_WORK_DIR=/work && make docker-RG351V` or `make DOCKER_WORK_DIR=/work docker-RG351V`
 
- The new `make docker-shell` command provides an easy way to get into a `shell` inside the build container.  This allows you to run whatever commands you want - useful if you do not have build tools available on your host (or host is not ubuntu 20.04, etc)

   Example running: `DEVICE=RG351V ./scripts/build 351elec`:
   ```
   :~/351ELEC$ make docker-shell
   docker@41aded309c0e:/work$ DEVICE=RG351V ./scripts/build 351elec
   BUILD      make (host)
       TOOLCHAIN      configure (auto-detect)
   ```

## Implementation
- Change working directory.  Just pass `pwd` to docker command for working dir instead of `/work`.

- For `make docker-shell` make the docker command configurable to pass in `bash` instead of `make`.

- **Related Fix** - Also fix an issue where docker installations requiring `sudo` to run didn't work properly (code already attempted to detect and try with `sudo docker` if `docker` doesn't work, but was choking on the error message)

- Keep build server using /work as it may present interesting options to share a single directory (or rsync) between different builders in the future.