### PR TITLE
Simplify PR Workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ A major advantage of using GitHub actions with a self hosted server - as opposed
   - **Logic**: An 'incremental' build (no `make clean`) is run on every commit to `main`.  All *build.* directories are saved between builds.
   - If a 'full' build is required.  `make clean` can be run manually by 351ELEC admins via the Github UI.  Driven by: [clean-main.yaml](docs/clean-main.yaml)
 - **Pull Requests**. Driven by [build-pr.yaml](build-pr.yaml)
-  - **Logic**: An 'incremental' build (no `make clean`) is run on every PR which: 1. Has requested reviewers OR 2. Is from a 351ELEC branch.  
+  - **Logic**: An 'incremental' build (no `make clean`) is run on every PR which is from a previous committer. 
     - Limiting the PRs built is done for security to ensure randomly submitted PRs are not built without some level of review (only 351ELEC admins are allowed to request reviewers)
   - If a 'full' PR build is required `make clean` can be run manually by 351ELEC admins for the PR builder.  Driven by: [clean-pr.yaml](docs/clean-pr.yaml)
 

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,6 +1,6 @@
 name: build-pr
 on:
-  pull_request_target:
+  pull_request:
   
     # We don't need to run builds when these files change
     paths-ignore:
@@ -10,9 +10,7 @@ on:
       - '.dockerignore'
     branches:
       - main
-
-    #Ensure we build when a review is requested (as we don't build w/o a review)
-    types: [opened, review_requested, synchronize]
+    types: [opened, synchronize]
 
 # Ensure that if there are multiple builds for a PR only 1 is queued
 # Example: 1st commit in PR starts a build then 2-9 commits come in during the first build.
@@ -24,11 +22,6 @@ jobs:
   build:
     # Run on self-hosted runners with the 'pr' label
     runs-on: pr
-
-    # Only run if: 1. There are reviewers requested. 2. The branch is from the 351ELEC repo (and thus 'safe' to build as very few people should have access to create branches)
-    if: | 
-       github.event.pull_request.requested_reviewers[0] != null
-         || github.event.pull_request.head.repo.owner.login == '351ELEC'
     steps:
       - uses: actions/checkout@v2
         name: checkout (pull request)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ make docker-world
 ```
 
 ## Automated Dev Builds
-Builds are automatically run on commits to `main` and for Pull Requests (*PR's*) that have been requested for review.  Reviews must be requested by existing team members for security purposes.
+Builds are automatically run on commits to `main` and for Pull Requests (*PR's*) from previous committers.
 
 Development builds can be found looking for the green checkmarks next to commit history.  Artifacts are generated for each build which can be used to update the RG351P/RG351V and are stored for 30 days by GitHub.  Note that due to Github Action limitations, artifacts are zipped (.img.gz and .tar are inside the zip file).
 


### PR DESCRIPTION
## Summary
I noticed one of my PR's didn't get built: https://github.com/351ELEC/351ELEC/pull/472.  It appears reason is because there was no reviewer requested, but it was just *approved* (which didn't match the `if` trigger logic as the reviewer wasn't *requested*).  

In researching this, it appears Github has recently made changes to deny running actions from users who haven't committed.  See: https://github.blog/changelog/2021-04-22-github-actions-maintainers-must-approve-first-time-contributor-workflow-runs/ This means we should just get rid of our `if review requested` checks and rely on Github to only build PRs from previous committers.

I also realized, we no longer need `pull_request_target` (vs `pull_request`) as we don't need any secrets to launch an AWS builder.  I don't think it's a huge difference, but is more secure to use `pull_request` so we should switch just in case.