### PR TITLE
Fix issue with builds running concurrently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ docker-%: GID := $(shell id -g)
 docker-%: PWD := $(shell pwd)
 
 # Use 'sudo' if docker ps doesn't work.  In theory, other things than missing sudo could cause this.  But sudo needed is a common issue and easy to fix.
-docker-%: SUDO := $(shell if ! docker ps -q 2> /dev/null; then echo "sudo"; fi)
+docker-%: SUDO := $(shell if ! docker ps -q 2> /dev/null 1> /dev/null; then echo "sudo"; fi)
 
 # Launch docker as interactive if this is an interactive shell (allows ctrl-c for manual and running non-interactive - aka: build server)
 docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")


### PR DESCRIPTION
# Summary
If there's another docker container running when `make docker-*` is run ( such as a `pr` build running when the `main` build starts)  - the ID of the running containers will (inadvertantly) be pre-pended to the docker command and it will faill.  Like this build did: https://github.com/351ELEC/351ELEC/actions/runs/928285306  Ex:
```
b3f1ceb84a65 docker run  --rm --user 1001:1002 -v /var/runner/_work/351ELEC/351ELEC:/work -w /work "351elec/351elec-build:latest" make RG351P
/bin/sh: 1: b3f1ceb84a65: not found
```
## What happened
I made a mistake in https://github.com/351ELEC/351ELEC/pull/472 - specifically here: https://github.com/351ELEC/351ELEC/pull/472/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R69 

That line is trying to check if Docker works to see if use sudo or not.  I realize now that the previous method of redirecting all output to /dev/null didn't work because `&` needs to be escaped in a Makefile (`2>&1 > /dev/null`) and the fix I put in (`2> /dev/null`) works if you need to use `sudo`, but doesn't hide the output of the `docker ps` command if other containers are running and the command works.

## The fix
Rather than confusingly escape `&` in the Makefile, I think it's just better to explicitly redirect both stdout (`1` - and the actual output of `docker ps`) and standard error (`2` and any error messages output) like this: `2> /dev/null 1> /dev/null`