### PR TITLE
[WIP] Reenable updates 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build.*/
 /.fakeroot.*
 /.ccache-*
+/.env
 
 # automatically downloaded source files
 /sources/

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -1,0 +1,4 @@
+FROM 351elec/351elec-build:latest
+
+RUN DEVICE=RG351P ARCH=arm ./scripts build toolchain
+RUN DEVICE=RG351V ARCH=aarch64 ./scripts build toolchain

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ v-aarch64:
 update:
 	DEVICE=RG351P ARCH=aarch64 ./scripts/update_packages
 
+package:
+	./scripts/build ${PACKAGE}
+
 
 ## Docker builds - overview
 # docker-* commands just wire up docker to call the normal make command via docker
@@ -74,9 +77,11 @@ docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")
 # By default pass through anything after `docker-` back into `make`
 docker-%: COMMAND=make $*
 
+# Get .env file ready
+docker-%: $(shell env > .env)
+
 # If the user issues a `make docker-shell` just start up bash as the shell to run commands
 docker-shell: COMMAND=bash
-
 
 # Command: builds docker image locally from Dockerfile
 docker-image-build:
@@ -94,4 +99,4 @@ docker-image-push:
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:
-	$(SUDO) docker run $(INTERACTIVE) --rm --user $(UID):$(GID) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
+	$(SUDO) docker run $(INTERACTIVE) --env-file .env --rm --user $(UID):$(GID) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -2,24 +2,85 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2020-present Fewtarius
 
+STORAGE_DIR="/storage"
+CONSOLE_DEVICE=/dev/console
 . /etc/profile
 
-### Disable update functionality
-exit 0
+# Maybe determine better way to identify 'test'
+if [ -d "${STORAGE_DIR}" ]; then
+  echo "Running on RG351 Device"
+else
+  echo "Running on generic linux device - test mode"
+  sleep 1
+  TEST="true"
 
-ARCH="$(cat /storage/.config/.OS_ARCH)"
+  STORAGE_DIR="./test"
+  # ouput to stdout instead of /dev/console
+  CONSOLE_DEVICE=/dev/stdout
+
+  # setup versions for testing
+  TEST_VERSION=20200703
+  TEST_DEVICE=RG351V
+
+  # Setup 'test' directory to simulate a real system
+  CONFIG_DIR="${STORAGE_DIR}/.config"
+  mkdir -p ${CONFIG_DIR}
+  ARCH="${TEST_DEVICE}"
+  echo "20200703" > ${CONFIG_DIR}/.OS_VERSION
+
+  #Test versions of functions
+  function get_ee_setting {
+    echo "daily"
+  }
+  function message_stream {
+    echo -e "${1}"
+  }
+  function reboot_system {
+    if [ "${TEST}" == "true" ]; then
+      echo "test: reboot"
+    else
+      reboot
+    fi
+  }
+fi
+
+function stop_emustation {
+  echo "Stopping emustation..."
+  if [[ "$TEST" == "true" ]]; then
+     echo "systemctl stop emustation"
+  else
+     systemctl stop emustation
+  fi
+}
+function start_emustation {
+  echo "Starting emustation..."
+  if [[ "$TEST" == "true" ]]; then
+     echo "test: systemctl start emustation"
+  else
+     systemctl start emustation
+  fi
+}
+
+function show_splash {
+
+  if [[ "$TEST" == "true" ]]; then
+    echo "test:  /usr/bin/show_splash.sh $1"
+  else
+    /usr/bin/show_splash.sh "$1"
+  fi
+}
 
 ### Modifiable variables
-USTAGE="/storage/roms/update"
+USTAGE="${STORAGE_DIR}/roms/update"
 PREFIX="351ELEC-${ARCH}.aarch64"
-MYVERSION=$(cat /storage/.config/.OS_VERSION)
+MYVERSION=$(cat ${STORAGE_DIR}/.config/.OS_VERSION)
 VERBOSE=true
 BAND=$(get_ee_setting updates.type)
-OS_SHA256="/storage/.config/.OS_SHA256"
+OS_SHA256="${STORAGE_DIR}/.config/.OS_SHA256"
 
 ### Functions Library
 
-if [ "${BAND}" == "daily" ]
+if [ "${BAND}" == "daily" ] || [ "${BAND}" == "release" ]
 then
   API="https://api.github.com/repos/351ELEC/351elec"
   REPO="https://github.com/351ELEC/351ELEC"
@@ -64,7 +125,7 @@ function online_status() {
 function hash() {
   while true
   do
-    echo -n "#" >/dev/console
+    echo -n "#" >${CONSOLE_DEVICE}
     sleep 1
   done
 }
@@ -78,6 +139,9 @@ get_size() {
 }
 
 check_space() {
+  if [ "$TEST" == "true" ]; then
+    return 
+  fi
   MYSIZE="$(get_$1 $2)"
   VOLNAME="$3"
   REQUIRED="$4"
@@ -86,19 +150,18 @@ check_space() {
     NEEDED=$(( (${REQUIRED} - ${MYSIZE} ) / 1024 ))
     message_stream  "\n\nThere is not enough free space available on the ${VOLNAME} volume to install this update.  Free up an additional ${NEEDED}MB, or reflash this version." .02
     sleep 10
-    clear >/dev/console
-    systemctl start emustation
+    clear > ${CONSOLE_DEVICE}
+    start_emustation
     exit 1
   fi
 }
 
 ### Main
 
-systemctl stop emustation
-
-clear >/dev/console
-/usr/bin/show_splash.sh "$0"
-clear >/dev/console
+stop_emustation
+clear > ${CONSOLE_DEVICE}
+show_splash "$0"
+clear > ${CONSOLE_DEVICE}
 
 if [ ! -d "${USTAGE}" ]
 then
@@ -134,8 +197,8 @@ then
   $VERBOSE && log "No update available ${MYVERSION} >= ${TAG}"
   message_stream "\n\nNo update is available, nothing to do..." .02
   sleep 4
-  clear >/dev/console
-  systemctl start emustation
+  clear > ${CONSOLE_DEVICE}
+  start_emustation
   exit 0
 else
   $VERBOSE && log "Update available ${TAG} > ${MYVERSION}"
@@ -201,12 +264,12 @@ then
   message_stream "\nVerification failed, cleaning up and exiting..." .02
   rm -f ${USTAGE}/*
   sleep 4
-  clear >/dev/console
-  systemctl start emustation
+  clear > ${CONSOLE_DEVICE}
+  start_emustation
   exit 1
 else
   # If we are sure that we will do the update we store the sha256 checksum into
-  # /storage/.config/.OS_SHA256 for /usr/bin/updatecheck to verify if the
+  # ${STORAGE_DIR}/.config/.OS_SHA256 for /usr/bin/updatecheck to verify if the
   # latest update is already installed or not
   echo $DLSUM > ${OS_SHA256}
   message_stream "\nVerification successful..." .02
@@ -216,4 +279,4 @@ $VERBOSE && log "Syncing..."
 message_stream "\n\nRebooting to continue update..." .02
 sync
 $VERBOSE && log "rebooting.."
-reboot
+reboot_system

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -25,7 +25,7 @@ else
   # Setup 'test' directory to simulate a real system
   CONFIG_DIR="${STORAGE_DIR}/.config"
   mkdir -p ${CONFIG_DIR}
-  ARCH="${TEST_DEVICE}"
+  echo "${TEST_DEVICE}" > ${CONFIG_DIR}/.OS_ARCH
   echo "20200703" > ${CONFIG_DIR}/.OS_VERSION
 
   #Test versions of functions
@@ -35,14 +35,14 @@ else
   function message_stream {
     echo -e "${1}"
   }
-  function reboot_system {
-    if [ "${TEST}" == "true" ]; then
-      echo "test: reboot"
-    else
-      reboot
-    fi
-  }
 fi
+function reboot_system {
+  if [ "${TEST}" == "true" ]; then
+    echo "test: reboot"
+  else
+    reboot
+  fi
+}
 
 function stop_emustation {
   echo "Stopping emustation..."
@@ -72,6 +72,7 @@ function show_splash {
 
 ### Modifiable variables
 USTAGE="${STORAGE_DIR}/roms/update"
+ARCH="$(cat ${STORAGE_DIR}/.config/.OS_ARCH)"
 PREFIX="351ELEC-${ARCH}.aarch64"
 MYVERSION=$(cat ${STORAGE_DIR}/.config/.OS_VERSION)
 VERBOSE=true

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -2,162 +2,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2020-present Fewtarius
 
+#Constants
 STORAGE_DIR="/storage"
 CONSOLE_DEVICE=/dev/console
 . /etc/profile
-
-# Maybe determine better way to identify 'test'
-if [ -d "${STORAGE_DIR}" ]; then
-  echo "Running on RG351 Device"
-else
-  echo "Running on generic linux device - test mode"
-  sleep 1
-  TEST="true"
-
-  STORAGE_DIR="./test"
-  # ouput to stdout instead of /dev/console
-  CONSOLE_DEVICE=/dev/stdout
-
-  # setup versions for testing
-  TEST_VERSION=20200703
-  TEST_DEVICE=RG351V
-
-  # Setup 'test' directory to simulate a real system
-  CONFIG_DIR="${STORAGE_DIR}/.config"
-  mkdir -p ${CONFIG_DIR}
-  echo "${TEST_DEVICE}" > ${CONFIG_DIR}/.OS_ARCH
-  echo "20200703" > ${CONFIG_DIR}/.OS_VERSION
-
-  #Test versions of functions
-  function get_ee_setting {
-    echo "daily"
-  }
-  function message_stream {
-    echo -e "${1}"
-  }
-fi
-function reboot_system {
-  if [ "${TEST}" == "true" ]; then
-    echo "test: reboot"
-  else
-    reboot
-  fi
-}
-
-function stop_emustation {
-  echo "Stopping emustation..."
-  if [[ "$TEST" == "true" ]]; then
-     echo "systemctl stop emustation"
-  else
-     systemctl stop emustation
-  fi
-}
-function start_emustation {
-  echo "Starting emustation..."
-  if [[ "$TEST" == "true" ]]; then
-     echo "test: systemctl start emustation"
-  else
-     systemctl start emustation
-  fi
-}
-
-function show_splash {
-
-  if [[ "$TEST" == "true" ]]; then
-    echo "test:  /usr/bin/show_splash.sh $1"
-  else
-    /usr/bin/show_splash.sh "$1"
-  fi
-}
-
-### Modifiable variables
-USTAGE="${STORAGE_DIR}/roms/update"
-ARCH="$(cat ${STORAGE_DIR}/.config/.OS_ARCH)"
-PREFIX="351ELEC-${ARCH}.aarch64"
-MYVERSION=$(cat ${STORAGE_DIR}/.config/.OS_VERSION)
-VERBOSE=true
-BAND=$(get_ee_setting updates.type)
-OS_SHA256="${STORAGE_DIR}/.config/.OS_SHA256"
-
-### Functions Library
-
-if [ "${BAND}" == "daily" ] || [ "${BAND}" == "release" ]
-then
-  API="https://api.github.com/repos/351ELEC/351elec"
-  REPO="https://github.com/351ELEC/351ELEC"
-  PROVIDER="git"
-fi
-
-if [ -e "${USTAGE}/update.log" ]
-then
-  rm "${USTAGE}/update.log"
-fi
-
-function getlatest() {
-  if [ "${PROVIDER}" == "https" ]
-  then
-    ### Clean this up later.
-    LATEST=$(curl -H 'Cache-Control: no-cache' -sL ${REPO} | grep -o '<a .*href=.*>' | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | sed -e 's#/.*$##g' | grep '^[0-9]' | sort | tail -n 1)
-    TAG=$(curl -H 'Cache-Control: no-cache' -sL ${REPO}/${LATEST}/aarch64/${ARCH} | grep -o '<a .*href=.*>' | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | sed -e 's#/.*$##g' | grep '^[0-9]' | sort | tail -n 1 | cut -d"-" -f 3 | cut -d"." -f 1,2)
-    REPO="${REPO}/${LATEST}/aarch64/${ARCH}"
-    UFILE="${PREFIX}-${TAG}.tar"
-  elif [ "${PROVIDER}" == "git" ]
-  then
-    TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases" | python -c "import sys, json; print(json.load(sys.stdin)[0]['tag_name'])")
-    REPO="${REPO}/releases/download/${TAG}"
-    UFILE="${PREFIX}-${TAG}.tar"
-  fi
-}
-
-function log () {
-  echo "$(date): $1" | tee -a "${USTAGE}/update.log"
-}
-
-function online_status() {
-  GW=$(ip route | awk '/eth0/ {a=$0} END{print $1}')
-  if [[ ${GW} =~ [0-9] ]]
-  then
-    echo true
-  else
-    echo false
-  fi
-}
-
-function hash() {
-  while true
-  do
-    echo -n "#" >${CONSOLE_DEVICE}
-    sleep 1
-  done
-}
-
-get_available() {
-  echo $(df | awk '/'$1'/ {printf $4; exit}')
-}
-
-get_size() {
-  echo $(df | awk '/'$1'/ {printf $2; exit}')
-}
-
-check_space() {
-  if [ "$TEST" == "true" ]; then
-    return 
-  fi
-  MYSIZE="$(get_$1 $2)"
-  VOLNAME="$3"
-  REQUIRED="$4"
-  if [ "${MYSIZE}" -lt "${REQUIRED}" ]
-  then
-    NEEDED=$(( (${REQUIRED} - ${MYSIZE} ) / 1024 ))
-    message_stream  "\n\nThere is not enough free space available on the ${VOLNAME} volume to install this update.  Free up an additional ${NEEDED}MB, or reflash this version." .02
-    sleep 10
-    clear > ${CONSOLE_DEVICE}
-    start_emustation
-    exit 1
-  fi
-}
-
-### Main
+DIR=$(realpath $(dirname $0))
+. ${DIR}/update-utils
 
 stop_emustation
 clear > ${CONSOLE_DEVICE}
@@ -216,14 +66,8 @@ do
 done
 check_space available ${DEV} GAMES 3072000
 
-### 351ELEC 1.x needs 640MB, but 2.x needs 1GB on the boot volume.
-MAJOR=${TAG:0:1}
-if [ "${MAJOR}" -lt 2 ]
-then
-  BOOTREQ=640000
-else
-  BOOTREQ=1024000
-fi
+### 351ELEC 2.x needs 1GB on the boot volume.
+BOOTREQ=1024000
 
 check_space size mmcblk0p1 boot ${BOOTREQ}
 

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -54,7 +54,7 @@ then
   start_emustation
   exit 0
 else
-  $VERBOSE && log "Update available ${TAG} () >= ${MYVERSION} (${OS_SHA256})"
+  $VERBOSE && log "Update available ${TAG} > ${MYVERSION}"
 fi
 
 ### We need a minimum of 3GB free on the games volume to download and extract the update.

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -36,7 +36,9 @@ else
   fi
 fi
 
-if [ "${TAG}" -gt "${MYVERSION}" ]
+UPDATE_AVAILABLE="$(update_available)"
+
+if [ "${UPDATE_AVAILABLE}" != "no" ]
 then
   UPDATE=true
 else
@@ -52,8 +54,7 @@ then
   start_emustation
   exit 0
 else
-  $VERBOSE && log "Update available ${TAG} > ${MYVERSION}"
-
+  $VERBOSE && log "Update available ${TAG} () >= ${MYVERSION} (${OS_SHA256})"
 fi
 
 ### We need a minimum of 3GB free on the games volume to download and extract the update.

--- a/packages/351elec/sources/scripts/update-utils
+++ b/packages/351elec/sources/scripts/update-utils
@@ -8,16 +8,14 @@ CONSOLE_DEVICE=/dev/console
 . /etc/profile
 
 # To make testing easier - allow running for ubuntu in 'test' mode
-if [ -d "${STORAGE_DIR}" ]; then
-  echo "Running on RG351 Device"
-else
+if [ ! -d "${STORAGE_DIR}" ]; then
   echo "Running on generic linux device - test mode"
-  sleep 1
   TEST="true"
   STORAGE_DIR="./test"
   
   # setup vars for testing
   TEST_VERSION=20210603
+  TEST_SHA=745ee8fd94ad41adc738bffb36ae24f5127036cb5ccaa548e8cb05639d2ff649
   TEST_DEVICE=RG351V
   TEST_BAND="release"
 
@@ -29,6 +27,7 @@ else
   mkdir -p ${CONFIG_DIR}
   echo "${TEST_DEVICE}" > ${CONFIG_DIR}/.OS_ARCH
   echo "${TEST_VERSION}" > ${CONFIG_DIR}/.OS_VERSION
+  echo "${TEST_SHA}" > ${CONFIG_DIR}/.OS_SHA256
 
   #Test versions of functions
   function get_ee_setting {
@@ -58,14 +57,11 @@ function getlatest() {
   # leave 'daily' band for backwards compatibility
   if [ "${BAND}" == "daily" ] || [ "${BAND}" == "release" ]
   then
-    API="https://api.github.com/repos/351ELEC/351elec"
-    REPO="https://github.com/351ELEC/351ELEC"
+    API="https://api.github.com/repos/pkegg/351elec"
+    REPO="https://github.com/pkegg/351ELEC"
     PROVIDER="git"
-  #maybe eventually have this pull from the latest actions
-  fi
-  if [ "${PROVIDER}" == "git" ]
-  then
-    TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases?per_page=100" | python3 -c "import sys, json; print([release for release in json.load(sys.stdin) if release['prerelease'] == False ][0]['tag_name'])")
+
+    TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases?per_page=100" | python3 -c "import sys, json; print([release for release in json.load(sys.stdin) if release['prerelease'] == False ][0]['tag_name'])" 2> /dev/null)
     REPO="${REPO}/releases/download/${TAG}"  
     UFILE="${PREFIX}-${TAG}.tar"
   else
@@ -154,4 +150,21 @@ check_space() {
     start_emustation
     exit 1
   fi
+}
+download_checksum() {
+    local CHECKSUM_FILE="$1"
+  	echo $(curl -H 'Cache-Control: no-cache' -Lo "${CHECKSUM_FILE}" "${REPO}/${PREFIX}-${TAG}.tar.sha256" &> /dev/null)
+}
+update_available() {
+    if [ -z "${TAG}" ]
+    then
+      echo "no"
+      return
+    fi
+    if [ "${TAG}" -ge "${MYVERSION}" ]
+    then
+      echo "${TAG} ${BAND^^}"
+    else
+      echo "no"
+    fi
 }

--- a/packages/351elec/sources/scripts/update-utils
+++ b/packages/351elec/sources/scripts/update-utils
@@ -1,0 +1,157 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2020-present Fewtarius
+
+#Constants
+STORAGE_DIR="/storage"
+CONSOLE_DEVICE=/dev/console
+. /etc/profile
+
+# To make testing easier - allow running for ubuntu in 'test' mode
+if [ -d "${STORAGE_DIR}" ]; then
+  echo "Running on RG351 Device"
+else
+  echo "Running on generic linux device - test mode"
+  sleep 1
+  TEST="true"
+  STORAGE_DIR="./test"
+  
+  # setup vars for testing
+  TEST_VERSION=20210603
+  TEST_DEVICE=RG351V
+  TEST_BAND="release"
+
+  # ouput to stdout instead of /dev/console
+  CONSOLE_DEVICE=/dev/stdout
+
+  # Setup 'test' directory to simulate a real system
+  CONFIG_DIR="${STORAGE_DIR}/.config"
+  mkdir -p ${CONFIG_DIR}
+  echo "${TEST_DEVICE}" > ${CONFIG_DIR}/.OS_ARCH
+  echo "${TEST_VERSION}" > ${CONFIG_DIR}/.OS_VERSION
+
+  #Test versions of functions
+  function get_ee_setting {
+    echo "${TEST_BAND}"
+  }
+  function message_stream {
+    echo -e "${1}"
+  }
+fi
+
+
+### Global Modifiable variables
+USTAGE="${STORAGE_DIR}/roms/update"
+ARCH="$(cat ${STORAGE_DIR}/.config/.OS_ARCH)"
+PREFIX="351ELEC-${ARCH}.aarch64"
+MYVERSION=$(cat ${STORAGE_DIR}/.config/.OS_VERSION)
+VERBOSE=true
+BAND=$(get_ee_setting updates.type)
+OS_SHA256="${STORAGE_DIR}/.config/.OS_SHA256"
+
+if [ -e "${USTAGE}/update.log" ]
+then
+  rm "${USTAGE}/update.log"
+fi
+
+function getlatest() {
+  # leave 'daily' band for backwards compatibility
+  if [ "${BAND}" == "daily" ] || [ "${BAND}" == "release" ]
+  then
+    API="https://api.github.com/repos/351ELEC/351elec"
+    REPO="https://github.com/351ELEC/351ELEC"
+    PROVIDER="git"
+  #maybe eventually have this pull from the latest actions
+  fi
+  if [ "${PROVIDER}" == "git" ]
+  then
+    TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases?per_page=100" | python3 -c "import sys, json; print([release for release in json.load(sys.stdin) if release['prerelease'] == False ][0]['tag_name'])")
+    REPO="${REPO}/releases/download/${TAG}"  
+    UFILE="${PREFIX}-${TAG}.tar"
+  else
+    echo "ERROR: No provider found for: ${PROVIDER}.  This is a coding error"
+    exit 1
+  fi
+}
+
+function reboot_system {
+  if [ "${TEST}" == "true" ]; then
+    echo "test: reboot"
+  else
+    reboot
+  fi
+}
+
+function stop_emustation {
+  echo "Stopping emustation..."
+  if [[ "$TEST" == "true" ]]; then
+     echo "systemctl stop emustation"
+  else
+     systemctl stop emustation
+  fi
+}
+function start_emustation {
+  echo "Starting emustation..."
+  if [[ "$TEST" == "true" ]]; then
+     echo "test: systemctl start emustation"
+  else
+     systemctl start emustation
+  fi
+}
+
+function show_splash {
+
+  if [[ "$TEST" == "true" ]]; then
+    echo "test:  /usr/bin/show_splash.sh $1"
+  else
+    /usr/bin/show_splash.sh "$1"
+  fi
+}
+
+function log () {
+  echo "$(date): $1" | tee -a "${USTAGE}/update.log"
+}
+
+function online_status() {
+  GW=$(ip route | awk '/eth0/ {a=$0} END{print $1}')
+  if [[ ${GW} =~ [0-9] ]]
+  then
+    echo true
+  else
+    echo false
+  fi
+}
+
+function hash() {
+  while true
+  do
+    echo -n "#" >${CONSOLE_DEVICE}
+    sleep 1
+  done
+}
+
+get_available() {
+  echo $(df | awk '/'$1'/ {printf $4; exit}')
+}
+
+get_size() {
+  echo $(df | awk '/'$1'/ {printf $2; exit}')
+}
+
+check_space() {
+  if [ "$TEST" == "true" ]; then
+    return 
+  fi
+  MYSIZE="$(get_$1 $2)"
+  VOLNAME="$3"
+  REQUIRED="$4"
+  if [ "${MYSIZE}" -lt "${REQUIRED}" ]
+  then
+    NEEDED=$(( (${REQUIRED} - ${MYSIZE} ) / 1024 ))
+    message_stream  "\n\nThere is not enough free space available on the ${VOLNAME} volume to install this update.  Free up an additional ${NEEDED}MB, or reflash this version." .02
+    sleep 10
+    clear > ${CONSOLE_DEVICE}
+    start_emustation
+    exit 1
+  fi
+}

--- a/packages/351elec/sources/scripts/update-utils
+++ b/packages/351elec/sources/scripts/update-utils
@@ -17,7 +17,7 @@ if [ ! -d "${STORAGE_DIR}" ]; then
   TEST_VERSION=20210603
   TEST_SHA=745ee8fd94ad41adc738bffb36ae24f5127036cb5ccaa548e8cb05639d2ff649
   TEST_DEVICE=RG351V
-  TEST_BAND="release"
+  TEST_BAND="beta"
 
   # ouput to stdout instead of /dev/console
   CONSOLE_DEVICE=/dev/stdout
@@ -55,19 +55,21 @@ fi
 
 function getlatest() {
   # leave 'daily' band for backwards compatibility
-  if [ "${BAND}" == "daily" ] || [ "${BAND}" == "release" ]
+  if [ "${BAND}" == "release" ]
   then
-    API="https://api.github.com/repos/pkegg/351elec"
-    REPO="https://github.com/pkegg/351ELEC"
-    PROVIDER="git"
-
-    TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases?per_page=100" | python3 -c "import sys, json; print([release for release in json.load(sys.stdin) if release['prerelease'] == False ][0]['tag_name'])" 2> /dev/null)
-    REPO="${REPO}/releases/download/${TAG}"  
-    UFILE="${PREFIX}-${TAG}.tar"
+    FILTER="if release['prerelease'] == False"
   else
-    echo "ERROR: No provider found for: ${PROVIDER}.  This is a coding error"
-    exit 1
+    FILTER=""
   fi
+
+  API="https://api.github.com/repos/pkegg/351elec"
+  REPO="https://github.com/pkegg/351ELEC"
+  PROVIDER="git"
+
+  TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases?per_page=100" | python3 -c "import sys, json; print([release for release in json.load(sys.stdin) ${FILTER}][0]['tag_name'])" 2> /dev/null)
+  REPO="${REPO}/releases/download/${TAG}"  
+  UFILE="${PREFIX}-${TAG}.tar"
+
 }
 
 function reboot_system {

--- a/packages/351elec/sources/scripts/updatecheck
+++ b/packages/351elec/sources/scripts/updatecheck
@@ -3,54 +3,9 @@
 # Copyright (C) 2020-present Fewtarius
 
 . /etc/profile
+DIR=$(realpath $(dirname $0))
 
-### Disable update functionality
-exit 0
-
-ARCH="$(cat /storage/.config/.OS_ARCH)"
-
-### Modifiable variables
-USTAGE="/storage/roms/update"
-PREFIX="351ELEC-${ARCH}.aarch64"
-MYVERSION=$(cat /storage/.config/.OS_VERSION)
-VERBOSE=true
-BAND=$(get_ee_setting updates.type)
-OS_SHA256="/storage/.config/.OS_SHA256"
-
-### Functions Library
-
-if [ "${BAND}" == "daily" ]
-then
-  API="https://api.github.com/repos/351ELEC/351elec"
-  REPO="https://github.com/351ELEC/351ELEC"
-  PROVIDER="git"
-fi
-
-function online_status() {
-  GW=$(ip route | awk '/eth0/ {a=$0} END{print $1}')
-  if [[ ${GW} =~ [0-9] ]]
-  then
-    echo true
-  else
-    echo false
-  fi
-}
-
-function getlatest() {
-  if [ "${PROVIDER}" == "https" ]
-  then
-    ### Clean this up later.
-    LATEST=$(curl -H 'Cache-Control: no-cache' -sL ${REPO} | grep -o '<a .*href=.*>' | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | sed -e 's#/.*$##g' | grep '^[0-9]' | sort | tail -n 1)
-    TAG=$(curl -H 'Cache-Control: no-cache' -sL ${REPO}/${LATEST}/aarch64/${ARCH} | grep -o '<a .*href=.*>' | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | sed -e 's#/.*$##g' | grep '^[0-9]' | sort | tail -n 1 | cut -d"-" -f 3 | cut -d"." -f 1,2,3)
-    REPO="${REPO}/${LATEST}/aarch64/${ARCH}"
-    UFILE="${PREFIX}-${TAG}.tar"
-  elif [ "${PROVIDER}" == "git" ]
-  then
-    TAG=$(curl -H 'Cache-Control: no-cache' -Ls "${API}/releases" | python -c "import sys, json; print(json.load(sys.stdin)[0]['tag_name'])")
-    REPO="${REPO}/releases/download/${TAG}"
-    UFILE="${PREFIX}-${TAG}.tar"
-  fi
-}
+. ${DIR}/update-utils
 
 ### Main
 
@@ -66,7 +21,7 @@ else
   fi
 fi
 
-if [ "${TAG}" -gt "${MYVERSION}" ]
+if [ "${TAG}" -ge "${MYVERSION}" ]
 then
   # We may be able to deprecate this now.  Will leave for a while though.
   # If there is an update we still have to check if it's a new one

--- a/packages/351elec/sources/scripts/updatecheck
+++ b/packages/351elec/sources/scripts/updatecheck
@@ -21,31 +21,18 @@ else
   fi
 fi
 
+UPDATE_AVAILABLE=$(update_available)
+if [ -z "${TAG}" ]
+then
+  echo "no"
+  exit 1
+fi
+
 if [ "${TAG}" -ge "${MYVERSION}" ]
 then
-  # We may be able to deprecate this now.  Will leave for a while though.
-  # If there is an update we still have to check if it's a new one
-  # this is done by comparing the sha256 checksum to the one of
-  # the last installed package. This information is written by 
-  # /usr/bin/351elec-upgrade while it fetches the next update
-  # The checksum is stored in /storage/.config/.OS_SHA256
-  LSHA=$(cat ${OS_SHA256})
-  if [ ! "$LSHA" == "" ]; then
-	curl -H 'Cache-Control: no-cache' -Lo "${USTAGE}/${PREFIX}-${TAG}.sha256" "${REPO}/${PREFIX}-${TAG}.sha256" &> /dev/null
-	DLSUM=$(cat ${USTAGE}/${PREFIX}-${TAG}.sha256 | awk '{print $1}')
-	rm -f ${USTAGE}/${PREFIX}-${TAG}.sha256
-	if [ "${LSHA}" == "${DLSUM}" ]; then
-		# we are called by '/usr/bin/batocera-config canupdate'
-		# and that expects a 'no' in return if there are no new updates
-		# '/usr/bin/batocera-config canupdate' itself is called by
-		# ES (ApiSystem.cpp) to check if there are any new updates.
-		echo "no"
-		exit 1
-	fi
-  fi
   echo "${TAG} ${BAND^^}"
   exit 0
 else
-  echo "NO UPDATE AVAILABLE"
+  echo "no"
   exit 1
 fi

--- a/packages/addons/addon-depends/bash/package.mk
+++ b/packages/addons/addon-depends/bash/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="604d9eec5e4ed5fd2180ee44dd756ddca92e0b6aa4217bbab2b6227380317f23"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/bash/bash.html"
 PKG_URL="ftp://ftp.cwru.edu/pub/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain ncurses"
+PKG_DEPENDS_TARGET="toolchain ncurses readline"
 PKG_LONGDESC="The GNU Bourne Again shell."
 
 PKG_CONFIGURE_OPTS_TARGET="--with-curses \

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="2da822c52e6c7f46791c91914bfb5d24cf357c83"
+PKG_VERSION="92f266871359dc0ca023033128a084c4b2e591f7"
 PKG_GIT_CLONE_BRANCH="reenable-updates"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="9d60aa0be1bda3f0fbbb04e95ecbc299801ae078"
+PKG_VERSION="2da822c52e6c7f46791c91914bfb5d24cf357c83"
 PKG_GIT_CLONE_BRANCH="reenable-updates"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="b24f4dde3cf1b265560da9c09411dd6d7396651e"
+PKG_VERSION="9d60aa0be1bda3f0fbbb04e95ecbc299801ae078"
 PKG_GIT_CLONE_BRANCH="reenable-updates"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="c1af3fb4349718859e4364670b58551914acf078"
+PKG_VERSION="b24f4dde3cf1b265560da9c09411dd6d7396651e"
 PKG_GIT_CLONE_BRANCH="reenable-updates"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="d95eddf98e6a55db204ca0d1fa7dc4fb82e73d09"
-PKG_GIT_CLONE_BRANCH="main"
+PKG_VERSION="c1af3fb4349718859e4364670b58551914acf078"
+PKG_GIT_CLONE_BRANCH="reenable-updates"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/351ELEC/351elec-emulationstation"
+PKG_SITE="https://github.com/pkegg/351elec-emulationstation"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain SDL2 freetype curl freeimage bash rapidjson ${OPENGLES} SDL2_mixer libcec fping p7zip vlc"
 PKG_NEED_UNPACK="busybox"


### PR DESCRIPTION
Work in progress - making draft PR to get some builds to test out updates.

# Summary
Automatic updates are an ideal user experience as user's don't need to use anything not on the device (assuming they have wifi).  This change attempts to ensure we can reenable automated updates without major issues in future version.

## Tasks
- [Done] Ensure automatic upgrade works from device to github releases (currently hooked up to test pkegg repo)
- [Done] Switch `daily` release channel to `release` and ensure upgrade from `daily` works properly.
- [Done] Ensure update notification is readded so that a notification is shown on the device if available.
- [Done] Refactor `updatescheck` and `351elec-upgrade` scripts to remove duplication (added `update-utils`)
- [Done] Enable a 'beta' channel which will include github 'prereleases'.  This allows pushing out beta/rc releases into github without everyone getting them. 
- [Not Started] Make a real python script for parsing github releases and their response.  Current 1 liner I don't think will be enough and is hard to understand/maintain/extend.
  - [Not Started] Plan for a scenario where there is a max version needed for this update script (for example, newer versions than 2021-11-11 will break, so we need the user to upgrade to that version before upgrading again, etc).  Thinking about some kind of github label (`update-v2-latest`) which we could check for and use if present.
- [Not Started] maybe make a separate PR?  - Add dev channel for development builds.  This is more difficult as there's an open question of whether to use the actions artifacts (which will be deleted in 30 days) or if we should publish prerelease 'releases' on every commit to `main`.
- [Not Started] - Extensive testing to ensure this doesn't break and look bad.