### PR TITLE
mGBA performance improvement

### DIFF
--- a/packages/games/libretro/mgba/package.mk
+++ b/packages/games/libretro/mgba/package.mk
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="mgba"
-PKG_VERSION="4f3fcfac78f0ecd5e6309cc2a3f439650de2d529"
-PKG_SHA256="4133868db08b548c4615865e1a3fb46db89c654cfe739335a225fec7970ba231"
+PKG_VERSION="eb3ddbe4c4cf9ff0ad7c578e70ed1d78af455bd4"
+PKG_SHA256="31707c9878e7f75dc5441cb4433b2fb36ab4a5d7de965eb3385821ebdf62531a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2.0"

--- a/packages/games/libretro/mgba/package.mk
+++ b/packages/games/libretro/mgba/package.mk
@@ -42,7 +42,7 @@ make_target() {
   if [[ "$ARCH" =~ "arm" ]]; then
     make -f Makefile.libretro platform=unix-armv HAVE_NEON=1
   else
-    make -f Makefile.libretro platform=armv8_a35
+    make -f Makefile.libretro platform=goadvance
   fi
 }
 


### PR DESCRIPTION
# Summary
Creating PR to test if mGBA performance is improved with new flag.  Also updated mgba to latest version (that is version from may with fix - we were on April version)

Info
```
Hey All, you may get better performance with mgba if you change this line https://github.com/351ELEC/351ELEC/blob/9aa655bf25acc44ed790e34ae40c7f916170e17b/packages/games/libretro/mgba/package.mk#L45 from armv8_a35 to goadvance.  Those flags were upstreamed by me to that libretro repo sometime ago and the feedback I've received is that mgba performs better with that flag for ArkOS.  https://github.com/libretro/mgba/commit/eb3ddbe4c4cf9ff0ad7c578e70ed1d78af455bd4
```