### PR TITLE
No need to copy the bezels in the user space every time

### DIFF
--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -99,11 +99,13 @@ rsync --ignore-existing -raz /usr/config/remappings/* /storage/remappings/ &
 # Copy OpenBOR
 rsync --ignore-existing -raz /usr/config/openbor /storage &
 
-# copy bezel if it doesn't exists
-if [ ! -f "/storage/roms/bezels/default.cfg" ]; then
-  mkbezels/
-  rsync --ignore-existing -raz /usr/share/retroarch-overlays/bezels/* /storage/roms/bezels/ &
-fi
+## Not needed any more
+## copy bezel if it doesn't exists
+#if [ ! -f "/storage/roms/bezels/default.cfg" ]; then
+#  mkbezels/
+#  rsync --ignore-existing -raz /usr/share/retroarch-overlays/bezels/* /storage/roms/bezels/ &
+#fi
+##
 
 # Copy pico-8
 cp -f  "/usr/bin/pico-8.sh" "/storage/roms/pico-8/Start Pico-8.sh" &

--- a/packages/351elec/tmpfiles.d/351elec-dirs.conf
+++ b/packages/351elec/tmpfiles.d/351elec-dirs.conf
@@ -17,6 +17,7 @@ d    /storage/roms/atarilynx		0755 root root - -
 d    /storage/roms/atarist		0755 root root - -
 d    /storage/roms/atomiswave		0755 root root - -
 d    /storage/roms/BGM			0755 root root - -
+d    /storage/roms/bezels		0755 root root - -
 d    /storage/roms/bios			0755 root root - -
 d    /storage/roms/c16			0755 root root - -
 d    /storage/roms/c64			0755 root root - -


### PR DESCRIPTION
* No need to copy the system bezels over in the user space - `setsetting.sh` will use both locations and prefers the ones in the user space.
* Create `/roms/bezels` automatically