### PR TITLE
RG351V does not reboot when plugged in

### DIFF
--- a/projects/Rockchip/devices/RG351V/packages/u-boot/package.mk
+++ b/projects/Rockchip/devices/RG351V/packages/u-boot/package.mk
@@ -17,10 +17,11 @@ PKG_STAMP="$UBOOT_SYSTEM"
 PKG_NEED_UNPACK="$PROJECT_DIR/$PROJECT/bootloader"
 [ -n "$DEVICE" ] && PKG_NEED_UNPACK+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader"
 
-PKG_VERSION="7c793e2f138ee41eba20358508579768c8299d5a"
+PKG_VERSION="dec4b29fa92a646f559aebb9fbf082c8fca0d373"
 PKG_GIT_CLONE_SINGLE="yes"
 PKG_GIT_CLONE_DEPTH="1"
-PKG_URL="https://github.com/SummerSunGenius/RG351V_uboot.git"
+PKG_URL="https://github.com/christianhaitian/RG351-u-boot.git"
+PKG_GIT_CLONE_BRANCH="odroidgoA-v2017.09"
 GET_HANDLER_SUPPORT="git"
 
 post_patch() {

--- a/projects/Rockchip/devices/RG351V/packages/u-boot/package.mk
+++ b/projects/Rockchip/devices/RG351V/packages/u-boot/package.mk
@@ -17,11 +17,11 @@ PKG_STAMP="$UBOOT_SYSTEM"
 PKG_NEED_UNPACK="$PROJECT_DIR/$PROJECT/bootloader"
 [ -n "$DEVICE" ] && PKG_NEED_UNPACK+=" $PROJECT_DIR/$PROJECT/devices/$DEVICE/bootloader"
 
-PKG_VERSION="dec4b29fa92a646f559aebb9fbf082c8fca0d373"
+PKG_VERSION="592d654a993ef5c4d3615ea8b52db830397751ae"
 PKG_GIT_CLONE_SINGLE="yes"
 PKG_GIT_CLONE_DEPTH="1"
-PKG_URL="https://github.com/christianhaitian/RG351-u-boot.git"
-PKG_GIT_CLONE_BRANCH="odroidgoA-v2017.09"
+PKG_URL="https://github.com/pkegg/RG351V_uboot.git"
+PKG_GIT_CLONE_BRANCH="master"
 GET_HANDLER_SUPPORT="git"
 
 post_patch() {


### PR DESCRIPTION
The RG351V when it's plugged in displays a 'charging' icon when you briefly hit the power button.  Additionally, the charging icon shows when rebooting - and it **blocks** reboot.  This leads to a jarring experience when updating, etc, as the V requires manual intervention to turn it on after updating/rebooting.  Additionally, the P does not show this issue or have this functionality, so it is not really intentional.

The fix is just to disable the flag `CONFIG_DM_CHARGE_DISPLAY` on compilation.  I have forked and updated Anbernic's uboot for the V (which we are currently using) to do this.  You can see the change here: https://github.com/pkegg/RG351V_uboot/commit/592d654a993ef5c4d3615ea8b52db830397751ae