### PR TITLE
RG351V does not reboot when plugged in

### DIFF
--- a/projects/Rockchip/devices/RG351V/packages/u-boot/patches/0003-uboot-disable-charging.patch
+++ b/projects/Rockchip/devices/RG351V/packages/u-boot/patches/0003-uboot-disable-charging.patch
@@ -1,0 +1,13 @@
+diff --git a/configs/odroidgo2_defconfig b/configs/odroidgo2_defconfig
+index 707ac14..3b8f237 100644
+--- a/configs/odroidgo2_defconfig
++++ b/configs/odroidgo2_defconfig
+@@ -1010,7 +1010,7 @@ CONFIG_DM_REGULATOR_FIXED=y
+ CONFIG_REGULATOR_RK8XX=y
+ # CONFIG_DM_DVFS is not set
+ # CONFIG_CHARGER_BQ25700 is not set
+-CONFIG_DM_CHARGE_DISPLAY=y
++#CONFIG_DM_CHARGE_DISPLAY=y
+ CONFIG_CHARGE_ANIMATION=y
+ CONFIG_ROCKCHIP_PM=y
+ CONFIG_DM_PWM=y


### PR DESCRIPTION
Created a new PR with @dhwz's comments to create a patch instead of fork.  Thanks for the idea - I didn't realize how easily patching was integrated. patch is from: pkegg/RG351V_uboot@592d654 - I've tried to match naming/formatting of the patch with the others in u-boot.

# Summary
The RG351V when it's plugged in displays a 'charging' icon when you briefly hit the power button. Additionally, the charging icon shows when rebooting - and it blocks reboot. This leads to a jarring experience when updating, etc, as the V requires manual intervention to turn it on after updating/rebooting. Additionally, the P does not show this issue or have this functionality, so it is not really intentional.

The fix is just to disable the flag CONFIG_DM_CHARGE_DISPLAY on compilation.