### PR TITLE
RG351V: Add Volume Repeat and Fn Brightness control

### DIFF
--- a/packages/351elec/profile.d/99-distribution.conf
+++ b/packages/351elec/profile.d/99-distribution.conf
@@ -231,6 +231,20 @@ button1=8
 button2=4
 ee_evdev="auto"
 
+# Backup audio up (L3 + R2) as many RG351V's have bad audio buttons
+[AudioUp]
+program="/usr/bin/odroidgoa_utils.sh vol +"
+button1=8
+button2=11
+ee_evdev="auto"
+
+# Backup audio down (L3 + L2) as many RG351V's have bad audio buttons
+[AudioDown]
+program="/usr/bin/odroidgoa_utils.sh vol -"
+button1=8
+button2=10
+ee_evdev="auto"
+
 EOF
                 if [ "$2" == "mpv" ]
                 then

--- a/packages/351elec/sources/scripts/brightness
+++ b/packages/351elec/sources/scripts/brightness
@@ -6,6 +6,12 @@ MIN=0
 MAX=255
 STEP=3
 
+# Ensure set_ee_setting exists in all contexts
+if ! type set_ee_setting  >/dev/null
+then
+  source /etc/profile
+fi
+
 if [ ! -f /sys/class/backlight/backlight/brightness ]
 then
   echo "ERROR: There is no BRIGHTNESS object to manage."

--- a/packages/351elec/sources/scripts/brightness
+++ b/packages/351elec/sources/scripts/brightness
@@ -6,6 +6,9 @@ MIN=0
 MAX=255
 STEP=3
 
+#Ensure set_ee_setting is available - regardless of how this is run
+source /etc/profile
+
 if [ ! -f /sys/class/backlight/backlight/brightness ]
 then
   echo "ERROR: There is no BRIGHTNESS object to manage."

--- a/packages/351elec/sources/scripts/brightness
+++ b/packages/351elec/sources/scripts/brightness
@@ -6,9 +6,6 @@ MIN=0
 MAX=255
 STEP=3
 
-#Ensure set_ee_setting is available - regardless of how this is run
-source /etc/profile
-
 if [ ! -f /sys/class/backlight/backlight/brightness ]
 then
   echo "ERROR: There is no BRIGHTNESS object to manage."

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -3,71 +3,112 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Fewtarius
+#               2021-present pkegg
+
+### Summary
+#   This script listens to volume keys on the RG351V and adjusts volume
+#   Fn + Volume up/down will adjust brightness
+###
 
 # Source predefined functions and variables
 . /etc/profile
 
-RG351_DEVICE='/dev/input/by-path/platform-rg351-keys-event'
-RG351_CONTROLLER_DEVICE='/dev/input/event3'
-
+# Event examples for reference
 # type 1 (EV_KEY), code 114 (KEY_VOLUMEDOWN), value 1
 # type 1 (EV_KEY), code 115 (KEY_VOLUMEUP), value 1
 
-VOL='*(KEY_VOLUME*, value *'
-VOL_UP='*UP), value *'
-VOL_DOWN='*DOWN), value *'
-V_FUNC='*(BTN_TR2), value *'
-L3_FUNC='*(BTN_TL2), value *'
+
+RG351_DEVICE='/dev/input/by-path/platform-rg351-keys-event'  # Device for volume key events
+
+RG351_CONTROLLER_DEVICE='/dev/input/event3' # Joystick events (for Fn key)
+
+VOL_EVENT='*(KEY_VOLUME*, value *' # This matches all volume events
+
+VOL_UP='*UP), value *'  # Differentiate 'up' volume event
+VOL_DOWN='*DOWN), value *' #Differentiate 'down' volume event
+
+V_FUNC_KEY_EVENT='*(BTN_TR2), value *' # Matches all RG351V Fn key events
+
+# Matches if a button was pressed (1), released (0) or held down (2)
 PRESS='*value 1'
 RELEASE='*value 0'
 REPEAT_PRESS="* value 2"
+
+# Volume repeat
+# volume repeat speed is slower (every 5th repeat event) 
+#  as there are only 20 stop (0-100 by increments of 5)
+VOLUME_REPEAT_MOD=5
+
+# Brightness repeat
+# brightness repeat speed is faster (every 2nd repeat event) 
+#  as there are many stops (0-255 by increments of 3)
+BRIGHTNESS_REPEAT_MOD=5
+
+# Variable to keep track of Fn being currently pressed
 FUNC_PRESSED=no
 
+# Logic:
+#  - Listen to both:
+#    - 'rg351' events to get volume keys (not part of the joystick api)
+#    - 'joystick' events - as the V's 'fn' key is mapped to the joystick
+#  - Switch statement keeps high level cases to only 'volume' and 'V function key'
+#      this is to avoid processing for other events or creating a lot of cases as this will be called
+#      for all button pushes
+#  - Using 'read' means the loop is idle when no button is pressed
 
-(  evtest "${RG351_DEVICE}" &
+(  
+   evtest "${RG351_DEVICE}" &
    evtest "${RG351_CONTROLLER_DEVICE}" &
    wait 
 ) | while read line; do
-    #echo "$line"
+
     case $line in
-        (${VOL})
-          COMMAND="/usr/bin/odroidgoa_utils.sh vol"
-          UP="+"
-          DOWN="-"
-          REPEAT_MOD=5
-       
-          REPEAT_NUM=$(( ${REPEAT_NUM} + 1 ))
-          #echo "REPEAT NUM: ${REPEAT_NUM}"
+        (${VOL_EVENT})
+
+          # Setup for 'brightness' if Fn pressed
           if [[ "${FUNC_PRESSED}" == "yes" ]]; then
-            COMMAND=./brightness
+            COMMAND=/usr/bin/brightness
             UP="up"
             DOWN="down"
-            REPEAT_MOD=2
-          fi    
+            REPEAT_MOD=${BRIGHTNESS_REPEAT_MOD}
+          # Default to 'volume' if Fn is not pressed
+          else
+            COMMAND="/usr/bin/odroidgoa_utils.sh vol"
+            UP="+"
+            DOWN="-"
+            REPEAT_MOD=${VOLUME_REPEAT_MOD}
+          fi
+          
+          REPEAT_NUM=$(( ${REPEAT_NUM} + 1 ))
+
+          # This isn't time to evaluate repeat so just skip
           if [[ "$line" == ${REPEAT_PRESS} && $(( ${REPEAT_NUM} % ${REPEAT_MOD} )) != "0" ]]; then
              continue
           fi
+
+          # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
             ${COMMAND} ${UP}
           elif [[ "${line}" == ${VOL_DOWN} ]]; then
             ${COMMAND} ${DOWN}
           fi
         ;;
-        (${V_FUNC} | ${L3_FUNC})
-          #echo "$line"
+
+        (${V_FUNC_KEY_EVENT}) 
+
+          # We don't care about 'Fn' key repeats - continue
           if [[ "$line" == ${REPEAT_PRESS} ]]; then
              continue
           fi
-        #echo "func"
+
+          #Reset the number of repeats when Fn is pressed/release
+          #  as repeat speed is different between volume/brightness
           REPEAT_NUM=0
+
           if [[ "${line}" == ${PRESS} ]]; then
-            #echo "pressed"
             FUNC_PRESSED=yes
           elif [[ "${line}" == ${RELEASE} ]]; then
-            #echo "released"
             FUNC_PRESSED=no
-          #else
-            #echo "line: '${line}'"
           fi
         ;;
     esac

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,8 +9,6 @@
 #   Fn + Volume up/down will adjust brightness
 ###
 
-# Source predefined functions and variables
-. /etc/profile
 
 # Event examples for reference
 # type 1 (EV_KEY), code 114 (KEY_VOLUMEDOWN), value 1
@@ -35,14 +32,14 @@ RELEASE='*value 0'
 REPEAT_PRESS="* value 2"
 
 # Volume repeat
-# volume repeat speed is slower (every 5th repeat event) 
+# volume repeat speed is slower (every 8th repeat event) 
 #  as there are only 20 stop (0-100 by increments of 5)
-VOLUME_REPEAT_MOD=5
+VOLUME_REPEAT_MOD=8
 
 # Brightness repeat
-# brightness repeat speed is faster (every 2nd repeat event) 
+# brightness repeat speed is faster (every 4th repeat event) 
 #  as there are many stops (0-255 by increments of 3)
-BRIGHTNESS_REPEAT_MOD=5
+BRIGHTNESS_REPEAT_MOD=4
 
 # Variable to keep track of Fn being currently pressed
 FUNC_PRESSED=no

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-2.0-or-later
@@ -6,21 +7,68 @@
 # Source predefined functions and variables
 . /etc/profile
 
-DEVICE='/dev/input/by-path/platform-rg351-keys-event'
+RG351_DEVICE='/dev/input/by-path/platform-rg351-keys-event'
+RG351_CONTROLLER_DEVICE='/dev/input/event3'
 
 # type 1 (EV_KEY), code 114 (KEY_VOLUMEDOWN), value 1
 # type 1 (EV_KEY), code 115 (KEY_VOLUMEUP), value 1
 
-VOL_UP='*(KEY_VOLUMEUP), value 1*'
-VOL_DN='*(KEY_VOLUMEDOWN), value 1*'
+VOL='*(KEY_VOLUME*, value *'
+VOL_UP='*UP), value *'
+VOL_DOWN='*DOWN), value *'
+V_FUNC='*(BTN_TR2), value *'
+L3_FUNC='*(BTN_TL2), value *'
+PRESS='*value 1'
+RELEASE='*value 0'
+REPEAT_PRESS="* value 2"
+FUNC_PRESSED=no
 
-evtest "${DEVICE}" | while read line; do
+
+(  evtest "${RG351_DEVICE}" &
+   evtest "${RG351_CONTROLLER_DEVICE}" &
+   wait 
+) | while read line; do
+    #echo "$line"
     case $line in
-	(${VOL_UP})
-	/usr/bin/odroidgoa_utils.sh vol +
-	;;
-	(${VOL_DN})
-	/usr/bin/odroidgoa_utils.sh vol -
-	;;
+        (${VOL})
+          COMMAND="/usr/bin/odroidgoa_utils.sh vol"
+          UP="+"
+          DOWN="-"
+          REPEAT_MOD=5
+       
+          REPEAT_NUM=$(( ${REPEAT_NUM} + 1 ))
+          #echo "REPEAT NUM: ${REPEAT_NUM}"
+          if [[ "${FUNC_PRESSED}" == "yes" ]]; then
+            COMMAND=./brightness
+            UP="up"
+            DOWN="down"
+            REPEAT_MOD=2
+          fi    
+          if [[ "$line" == ${REPEAT_PRESS} && $(( ${REPEAT_NUM} % ${REPEAT_MOD} )) != "0" ]]; then
+             continue
+          fi
+          if [[ "${line}" == ${VOL_UP} ]]; then
+            ${COMMAND} ${UP}
+          elif [[ "${line}" == ${VOL_DOWN} ]]; then
+            ${COMMAND} ${DOWN}
+          fi
+        ;;
+        (${V_FUNC} | ${L3_FUNC})
+          #echo "$line"
+          if [[ "$line" == ${REPEAT_PRESS} ]]; then
+             continue
+          fi
+        #echo "func"
+          REPEAT_NUM=0
+          if [[ "${line}" == ${PRESS} ]]; then
+            #echo "pressed"
+            FUNC_PRESSED=yes
+          elif [[ "${line}" == ${RELEASE} ]]; then
+            #echo "released"
+            FUNC_PRESSED=no
+          #else
+            #echo "line: '${line}'"
+          fi
+        ;;
     esac
 done


### PR DESCRIPTION
# Summary (RG351V)
- Add 'repeat' into the volume listener so that holding down the volume button will continue to change the volume.  Before you needed to hit volume button again and again.
- Add support for 'Fn+Vol Up/Down' to change brightness.  So - if you hold down the Fn key on the RG351V and press the volume keys, brightess will be adjusted.  Repeat is also supported
- Add 'backup' volume hotkeys L3 + L2/R2 to change the volume.  Repeat is not supported.  This is similar to the existing L3+L1/R1 hotkeys to change brightness.  This hotkey applies to both RG351P and RG351V.

## Background
The reason for not using different buttons for brightness and instead using Fn + Vol Up/Down is that it cannot conflict with users existing assigned hotkeys in Retroarch or other emulators as the vol +/- buttons are not a 'joystick' and thus not available to them.

# Technical Details
- In order to do the 'repeat' functionality, we cannot use `jslisten` as it does not support repeat.  Instead, I updated the `volume_sense.sh` script to listen to both the RG351 specific events (volume/power) and the controller events (to get function key)
  - Due to the controller disconnecting and reconnecting, the `volume_sense.sh` script exists if the controller disconnects.  systemd will then restart.  The script also wait for the controller device to exist before monitoring as reconnect can take longer than systemd waits to restart.
  - There might be a better way to not have the script exit, but it is simple and works.
-  Due to the way the script listens to both the controller and RG351V keys, it is possible there are times where the output becomes interleaved (two lines combined into one), however, I've not seen this scenario and I believe the only negative effect would be skipping the first event when the two buttons (or their repeats) collide.
- I noticed that in the brightness script, there was an error with set_ee_settings not found.  This didn't affect brightness, but seems to affect ES.  So - after fixing this, if you set the brightness and then go into the 'System Settings' it is the correct value (the system settings screen does *not* update brightness if you change on that page).
