### PR TITLE
The V mounts the card of the p/m as games if in slot 2

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -709,7 +709,7 @@ mount_games() {
       /usr/bin/busybox mkdir -p /storage/roms >/dev/null 2>&1
     fi
 
-    for DEV in mmcblk1p1 mmcblk1 mmcblk0p3
+    for DEV in mmcblk1p3 mmcblk1p1 mmcblk1 mmcblk0p3
     do
       if [ -e "/dev/${DEV}" ] && [ ! -e "/storage/.please_resize_me" ]
       then


### PR DESCRIPTION
The V mounts the Games Partition of the M as games if in slot 2
Drawbacks:
* Retroarch Overrides that are device specific like scaling will be used as well
