### PR TITLE
Add PokeMini rumble patch

### DIFF
--- a/packages/games/libretro/pokemini/package.mk
+++ b/packages/games/libretro/pokemini/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pokemini"
-PKG_VERSION="3c03e988b8316998e1fdf1b2df76fbbf332e5bc3"
+PKG_VERSION="40092c4ea1f15fce877c0b942c4fe907b5f3b6ff"
 PKG_SHA256="5486f8bf81ac12c0de3dc9b869711da17f8d469e98117d0e81703266e22fba9c"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/packages/games/libretro/pokemini/package.mk
+++ b/packages/games/libretro/pokemini/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pokemini"
-PKG_VERSION="40092c4ea1f15fce877c0b942c4fe907b5f3b6ff"
+PKG_VERSION="3c03e988b8316998e1fdf1b2df76fbbf332e5bc3"
 PKG_SHA256="5486f8bf81ac12c0de3dc9b869711da17f8d469e98117d0e81703266e22fba9c"
 PKG_REV="1"
 PKG_ARCH="any"

--- a/packages/games/libretro/pokemini/patches/libretro_pokemini_rumble.patch
+++ b/packages/games/libretro/pokemini/patches/libretro_pokemini_rumble.patch
@@ -1,0 +1,55 @@
+diff --git a/libretro/libretro.c b/libretro/libretro.c
+index 1fbf38d..84b7ff2 100644
+--- a/libretro/libretro.c
++++ b/libretro/libretro.c
+@@ -169,26 +169,36 @@ static void InitialiseRumbleInterface(void)
+ 
+ static void ActivateControllerRumble(void)
+ {
+-	if (!rumble.set_rumble_state ||
+-		 (rumble_strength_prev == rumble_strength))
+-		return;
+-
+-	rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK,   rumble_strength);
+-	rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, rumble_strength);
+-	rumble_strength_prev = rumble_strength;
++	//if (!rumble.set_rumble_state ||
++	//	 (rumble_strength_prev == rumble_strength))
++	//	return;
++
++	//rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK,   rumble_strength);
++	//rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, rumble_strength);
++	FILE *fp;
++ 	fp = fopen("/sys/class/pwm/pwmchip0/pwm0/duty_cycle", "w");
++ 	fprintf(fp, "10");
++ 	fclose(fp);
++
++	//rumble_strength_prev = rumble_strength;
+ }
+ 
+ ///////////////////////////////////////////////////////////
+ 
+ static void DeactivateControllerRumble(void)
+ {
+-	if (!rumble.set_rumble_state ||
+-		 (rumble_strength_prev == 0))
+-		return;
+-
+-	rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK,   0);
+-	rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, 0);
+-	rumble_strength_prev = 0;
++	//if (!rumble.set_rumble_state ||
++	//	 (rumble_strength_prev == 0))
++	//	return;
++
++	//rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK,   0);
++	//rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, 0);
++	FILE *fp;
++ 	fp = fopen("/sys/class/pwm/pwmchip0/pwm0/duty_cycle", "w");
++ 	fprintf(fp, "1000000");
++ 	fclose(fp);
++
++	//rumble_strength_prev = 0;
+ }
+ 
+ ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds a patch to the PokeMini libretro core letting rumble work on these devices. I'm not entirely sure what I'm doing, I just saw what patches were needed to get rumble working on other cores, but this seems to work.