### PR TITLE
it adds FPS on screen on retrorun and fixes retrorun problem on V (black screen) 

### DIFF
--- a/packages/games/tools/retrorun/package.mk
+++ b/packages/games/tools/retrorun/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="retrorun"
-PKG_VERSION="a8fabc27780502a3ebc41e6b79f8e7ab74e3d1f7"
+PKG_VERSION="0ec798f493bfb6cb6b11f4e3ac71cee88bec27e1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/navy1978/retrorun-go2"

--- a/packages/games/tools/retrorun/package.mk
+++ b/packages/games/tools/retrorun/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="retrorun"
-PKG_VERSION="packages/games/tools/retrorun/package.mk"
+PKG_VERSION="2d59570802ca49ef8a76b6c5c7b1fee98ea3afb4"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/navy1978/retrorun-go2"

--- a/packages/games/tools/retrorun/package.mk
+++ b/packages/games/tools/retrorun/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="retrorun"
-PKG_VERSION="0ec798f493bfb6cb6b11f4e3ac71cee88bec27e1"
+PKG_VERSION="packages/games/tools/retrorun/package.mk"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/navy1978/retrorun-go2"

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -3,18 +3,25 @@ echo 'starting retrorun emulator...'
 if [ ! -f /storage/.config/distribution/configs/retrorun.cfg ]; then
   cp -f /usr/config/distribution/configs/retrorun.cfg /storage/.config/distribution/configs/
 fi
+if [ ! -f /storage/.config/distribution/configs/retrorun_v.cfg ]; then
+  cp -f /usr/config/distribution/configs/retrorun_v.cfg /storage/.config/distribution/configs/
+fi
+
 rm /dev/input/by-path/platform-odroidgo2-joypad-event-joystick || true
 echo 'creating fake joypad'
 /usr/bin/rg351p-js2xbox --silent -t oga_joypad &
 sleep 1
 echo 'confguring inputs'
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
+CONF_FILE= ''
 echo 'confguring inputs on device:'$EE_DEVICE
 if [[ "$EE_DEVICE" == "RG351V" ]]
 then
 	ln -s /dev/input/event4 /dev/input/by-path/platform-odroidgo2-joypad-event-joystick
+	CONF_FILE='/storage/packages/games/tools/retrorun/retrorun_v.cfg'
 else
 	ln -s /dev/input/event3 /dev/input/by-path/platform-odroidgo2-joypad-event-joystick
+	CONF_FILE='/storage/packages/games/tools/retrorun/retrorun.cfg'
 fi
 chmod 777 /dev/input/by-path/platform-odroidgo2-joypad-event-joystick
 sleep 1
@@ -33,10 +40,10 @@ if [[ "$1" =~ "pcsx_rearmed" ]] || [[ "$1" =~ "parallel_n64" ]] || [[ "$1" =~ "u
 then
     echo 'using 32bit'
   	export LD_LIBRARY_PATH="/usr/lib32"
-	/usr/bin/retrorun32 --triggers $FPS -n -s /storage/roms/"$3"  -d /roms/bios "$1" "$2"
+	/usr/bin/retrorun32 --triggers $FPS -n -s /storage/roms/"$3"  -d /roms/bios "$1" "$2" -c $CONF_FILE
 else
-	echo 'using 64bit'
-	/usr/bin/retrorun --triggers $FPS -n -s /storage/roms/"$3" -d /roms/bios "$1" "$2"
+    echo 'using 64bit'
+        /usr/bin/retrorun --triggers $FPS -n -s /storage/roms/"$3" -d /roms/bios "$1" "$2" -c $CONF_FILE
 fi
 sleep 1
 rm /dev/input/by-path/platform-odroidgo2-joypad-event-joystick

--- a/packages/games/tools/retrorun/retrorun_v.cfg
+++ b/packages/games/tools/retrorun/retrorun_v.cfg
@@ -1,0 +1,34 @@
+# ---- FLYCAST ----
+flycast_threaded_rendering = enabled
+flycast_internal_resolution = 640x480
+flycast_anisotropic_filtering = off
+flycast_enable_dsp = disabled
+flycast_synchronous_rendering = disabled
+flycast_enable_rtt = disabled
+flycast_enable_rttb = disabled
+flycast_delay_frame_swapping = disabled
+# Alpha sorting should be set to per strip
+flycast_alpha_sorting = per-strip (fast, least accurate)
+flycast_div_matching = auto
+# Texupscale should be off
+flycast_texupscale = off
+# Vibration support should be on
+flycast_enable_purupuru = enabled
+# ---- YABASNASHIRO ----
+# 4M extended ram enabled
+yabasanshiro_addon_cart = 4M_extended_ram
+# Frameskip should be on
+yabasanshiro_frameskip = enabled
+# Compute shader should be off
+yabasanshiro_rbg_use_compute_shader = disabled
+# Dynarec should be on
+yabasanshiro_sh2coretype = dynarec
+# Original Rbg resolution should be on
+yabasanshiro_rbg_resolution_mode = original
+# Original resolution should be on
+yabasanshiro_resolution_mode = original
+# Perspective correction resolution should be on for polygon mode
+yabasanshiro_polygon_mode = perspective_correction
+# ---- PARALLEL N64 ----
+# forcing resolution to 640x480 to solve black screen on V
+parallel-n64-screensize = 640x480


### PR DESCRIPTION
On P/M: tested with flycast , parallel n64 and parallel n64gl and everything works fine.
On V: everything works fine on flycast and parallel n64_gln64 and parallel n64 (we force, just for the last one, the resolution to be 640x480 to solve the black screen problem)
storage/.config/distribution/configs/retrorun.cfg have been split in two (one for both M and P and a specific one for V):
storage/.config/distribution/configs/retrorun.cfg
storage/.config/distribution/configs/retrorun_v.cfg

To recap, this version adds new features:

1) FPS on screen for all cores (and in both normal and Tate mode, rotated appropriately, when available)
2) Launching retrorun from command line a list of all core parameters with all possible values is provided, making it easies to configure the specific core (for testing purposes)
3) It fixes black-scren on V for parallel n64, this is done forcing the core resolution to 640x480, this is not the best approch perhaps, but at least it works. Compared with the current version (and all the previous retrorun versions included the very first one) It's a step forward, waiting for a different solution. (About that I tried to contact OtherCrashOverride on the odroid forum to check if he can help us to identify the problem)