### PR TITLE
Build: Skip Draft PR's

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -22,6 +22,8 @@ jobs:
   build:
     # Run on self-hosted runners with the 'pr' label
     runs-on: pr
+    # Don't run on drafts
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
         name: checkout (pull request)

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -10,7 +10,7 @@ on:
       - '.dockerignore'
     branches:
       - main
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 # Ensure that if there are multiple builds for a PR only 1 is queued
 # Example: 1st commit in PR starts a build then 2-9 commits come in during the first build.


### PR DESCRIPTION
### Problem
Draft PR's currently build automatically.  As draft often means this PR is not ready for consumption, the builds are annoying and frequently fail.

### Fix
- Tell github to only run builds that are not marked 'draft'
- Run builds on 'ready_for_review' event (which is the equivalent of 'opened' when changing a 'draft PR' into a real PR).

NOTE: If we ever have a use case to build draft PR's, we could easily add a 'label' to indicate they should build.