### PR TITLE
RG351V: Fix incorrect cpu speed in kernel

### DIFF
--- a/projects/Rockchip/devices/RG351V/packages/linux/patches/02-rg351v.patch
+++ b/projects/Rockchip/devices/RG351V/packages/linux/patches/02-rg351v.patch
@@ -374,6 +374,7 @@ diff -rupN linux.orig/arch/arm64/boot/dts/rockchip/rk3326-rg351p-linux.dts linux
 +	/delete-node/ opp-600000000;
 +	/delete-node/ opp-816000000;
 +	/delete-node/ opp-1416000000;
++	/delete-node/ opp-1512000000;
 +};
 +
 +&display_subsystem {


### PR DESCRIPTION
# Problem
The RG351V displays a different maximum clock speed than the P.  Additionally, this speed shown is **greater** than the even the overclocked CPU speed.  However, it appears this listed CPU speed does not actually result in higher performance and is mainly confusing.

Example showing the incorrect top frequency (`1512000`):
```
cat /sys/devices/system/cpu/cpufreq/policy0/scaling_available_frequencies 
1008000 1200000 1248000 1296000 1512000 
```

# Fix
In the kernel patch for the V, we need to add a `delete-node` option similar to how the P does it in order to remove the top CPU frequency 'step'

# Testing
Just in case it was possible that the highest frequency was actually causing some performance gains (instead of just being an error, etc), I ran some simple benchmarking.  The data is in seconds with average of the different runs on the bottom  See the script used to test CPU below.

It appears that CPU performance is equivalent between overclocked tests (4.26 seconds and 4.27 seconds) and that with the fix performance is slightly faster when not over clocked (4.38 seconds vs 4.51 seconds).  I'm not sure if this will result in any real world improvements, but it is enough to show that there is at least likely **not** any performance degradation with this fix.

V - with fix |   | V - with fix - overclocked |   | V - without fix |   | V - without fix - overclocked
-- | -- | -- | -- | -- | -- | --
4.383 |   | 4.301 |   | 4.466 |   | 4.218
4.346 |   | 4.248 |   | 4.549 |   | 4.292
4.418 |   | 4.194 |   | 4.485 |   | 4.293
4.416 |   | 4.31 |   | 4.576 |   | 4.372
4.414 |   | 4.222 |   | 4.6 |   | 4.266
4.352 |   | 4.294 |   | 4.472 |   | 4.25
4.415 |   |   |   | 4.468 |   | 4.253
4.361 |   |   |   | 4.533 |   | 4.247
  |   |   |   |   |   |  
4.388125 |   | 4.2615 |   | 4.518625 |   | 4.273875

Test script (run with `time bash <script>`) - adapted from: https://stackoverflow.com/a/13220272
```
NUMCPU=4
for ((i=0;i<$NUMCPU;i++));do
    echo 'scale=1000;pi=4*a(1);0' | bc -l &
    done ;\
    wait
```
