### PR TITLE
Game Boy / Game Boy Color: Fix cores in es_systems

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -580,7 +580,6 @@
           <core>tgbdual</core>
           <core>mgba</core>
           <core>vbam</core>
-          <core>vba_next</core>
         </cores>
       </emulator>
     </emulators>
@@ -600,11 +599,11 @@
       <emulator name="libretro">
         <cores>
           <core default="true">gambatte</core>
+          <core>sameboy</core>
           <core>gearboy</core>
           <core>tgbdual</core>
           <core>mgba</core>
           <core>vbam</core>
-          <core>vba_next</core>
         </cores>
       </emulator>
     </emulators>
@@ -674,7 +673,6 @@
           <core>tgbdual</core>
           <core>mgba</core>
           <core>vbam</core>
-          <core>vba_next</core>
         </cores>
       </emulator>
     </emulators>
@@ -694,11 +692,11 @@
       <emulator name="libretro">
         <cores>
           <core default="true">gambatte</core>
+          <core>sameboy</core>
           <core>gearboy</core>
           <core>tgbdual</core>
           <core>mgba</core>
           <core>vbam</core>
-          <core>vba_next</core>
         </cores>
       </emulator>
     </emulators>


### PR DESCRIPTION
Two things:

1 - VBA Next is a GBA only emulator, it had the GB/GBC part ripped out several years ago. Not a lot of point having it in the cores list for GB/C as it just raises an error

2 - SameBoy is missing from the (Hacks) systems for Game Boy and Game Boy Color, which seems inconsistent if the only purpose of those separate hack systems is for theming and organization, and there is nothing technically stopping anyone running hacks with SameBoy. Might have just been missed.