### PR TITLE
Remove Theme Art Book 3-2 from the V

### DIFF
--- a/packages/ui/351elec-emulationstation/themes/es-theme-art-book-3-2/package.mk
+++ b/packages/ui/351elec-emulationstation/themes/es-theme-art-book-3-2/package.mk
@@ -14,7 +14,9 @@ PKG_SHORTDESC="ArtBook"
 PKG_LONGDESC="Art Book - 351ELEC default theme for RG351P/M"
 PKG_TOOLCHAIN="manual"
 
-makeinstall_target() {
-  mkdir -p $INSTALL/usr/config/emulationstation/themes/$PKG_NAME
-  cp -rf * $INSTALL/usr/config/emulationstation/themes/$PKG_NAME
-}
+if [ "${DEVICE}" = "RG351P" ]; then
+  makeinstall_target() {
+    mkdir -p $INSTALL/usr/config/emulationstation/themes/$PKG_NAME
+    cp -rf * $INSTALL/usr/config/emulationstation/themes/$PKG_NAME
+  }
+fi


### PR DESCRIPTION
* Disable Theme Art-Book 3-2 for the V. The theme is copied over from `/usr/config/emulationstation/themes/` to `/storage/.emulationstation/themes` therefore it still will be there for users that upgrade from an older version.