### PR TITLE
Fix physfs build break

### DIFF
--- a/packages/games/emulators/solarus/physfs/package.mk
+++ b/packages/games/emulators/solarus/physfs/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="physfs"
-PKG_VERSION="610a844fa3d003fc8501dd2b0a1ce13d077a38b6"
+PKG_VERSION="009be5ab20b0e590c68039415a0768e6d4651808"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
-PKG_SITE="https://github.com/criptych/physfs"
+PKG_SITE="https://github.com/icculus/physfs"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain glm"
 PKG_SHORTDESC="PhysicsFS; a portable, flexible file i/o abstraction."


### PR DESCRIPTION
## Problem
It appears that the fork of physfs we were pointing to (https://github.com/criptych/physfs) had the commit we were referencing (610a844fa3d003fc8501dd2b0a1ce13d077a38b6) removed.  

It's hard to tell for sure, but I would guess this commit ended up being duplicated/squashed/etc into the main fork ('icculus') and at some point, cryptych's fork was rebased against it, losing the original commit.

## Solution
Googling for the revision, it appears that the commit was referenced was from January 18th.  Ex: https://github.com/Didstopia/physfs/commit/610a844fa3d003fc8501dd2b0a1ce13d077a38b6 is now this commit: https://github.com/criptych/physfs/commit/009be5ab20b0e590c68039415a0768e6d4651808.  Given this repository ('cryptich') for whatever reason, rewrote it's history, it's probably best to not use it - as it could cause more issues in the future.

It appears that criptych/physfs was forked from icculus/physfs and that the icculus now includes the same revision.  So - I think it's probably best to switch to the icculus repository.  @dhwz may know more history - feel free to update this PR (or push another change) if you still feel criptych's fork is the correct one.

Also - thanks to @Zowayix  for finding and reporting this issue.