### PR TITLE
Beta builds

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,5 +1,7 @@
 name: build-main
 on:
+  repository_dispatch:
+    types: [release-beta, release-draft]
   workflow_dispatch:
   push:
     paths-ignore:
@@ -19,6 +21,8 @@ jobs:
   build:
     runs-on: main
     steps:
+      - uses: hmarr/debug-action@v2
+        name: debug
       - uses: actions/checkout@v2
         name: checkout
         with:
@@ -29,19 +33,28 @@ jobs:
       - name: Get short SHA for artifacts
         id: sha
         run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
-      - name: Get dev version
+      - name: Get dev (or draft release) version
         id: version
-        run: echo "::set-output name=version::dev-${{ steps.date.outputs.date }}-${{ steps.sha.outputs.sha }}"
+        run: |
+           set -e
+           echo "full name: ${{ github.event.repository.full_name }}"
+           if [[ "${{ github.event.client_payload.release_tag }}" != "" ]]; then
+               echo "::set-output name=version::${{ github.event.client_payload.release_tag }}"
+           else
+               echo "::set-output name=version::dev-${{ steps.date.outputs.date }}-${{ steps.sha.outputs.sha }}"
+           fi
       - name: Build rg351P
         run: |
             set -e
             export CUSTOM_VERSION="${{ steps.version.outputs.version }}"
             make DOCKER_WORK_DIR=/work docker-RG351P
+
       - name: Build rg351V
         run: |
             set -e
             export CUSTOM_VERSION="${{ steps.version.outputs.version }}"
             make DOCKER_WORK_DIR=/work docker-RG351V
+
       - name: Cleanup system artifacts
         run: |
             set -e
@@ -49,14 +62,77 @@ jobs:
             rm -rf release/aarch64/RG351*/*.kernel*
       - name: Archive RG351V (${{github.sha}})
         uses: actions/upload-artifact@v2
+        if: github.event.client_payload.release_tag == ''
         with:
           name: RG351V-dev-main-${{ steps.date.outputs.date }}-${{steps.sha.outputs.sha}}
-
           path: |
             release/aarch64/RG351V/
       - name: Archive RG351P (${{github.sha}})
+        if: github.event.client_payload.release_tag == ''
         uses: actions/upload-artifact@v2
         with:
           name: RG351P-dev-main-${{ steps.date.outputs.date }}-${{steps.sha.outputs.sha}}
           path: |
             release/aarch64/RG351P/
+      - name: Create pre-release
+        if: github.event.action == 'release-beta'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "${{ steps.version.outputs.version }}"
+          body: |
+            # Release Notes (Beta)
+            This is a pre-release based on the commit: ${{github.sha}}.
+    
+            Beta releases are unstable and provided for the community.  Please DO NOT open issues on this build and instead post in the `#contribution-help` section of discord.
+            
+            See the [wiki](https://github.com/${{ github.event.repository.full_name }}/wiki/Contributing-to-351ELEC#]) for more info.
+            
+            ### Changes (since last beta version):
+            ${{ github.event.client_payload.release_notes }}
+            
+            ### Upgrade Instructions
+            You can update to this release using the`beta` channel on your device.  This is the recommended way to use beta versions.
+            
+             **IMPORTANT NOTE**: There are **two different images** below, one for the **RG351P/M** and one for the **RG351V**! 
+
+            **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)**
+
+          files: |
+            release/aarch64/RG351P/*
+            release/aarch64/RG351V/*
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        if: github.event.action == 'release-draft'
+        with:
+          tag_name: "${{ steps.version.outputs.version }}"
+          name: "351ELEC - ${{ steps.version.outputs.version }} - ${{ github.event.client_payload.release_name }}"
+          body: |
+            # Release Notes
+            Welcome to the ${{ github.event.client_payload.release_name}} (${{ steps.version.outputs.version }}) release.
+            
+            General:
+            
+            New Stuff:
+
+            Fixes:
+            
+            **IMPORTANT NOTE**: There are **two different images** below, one for the **RG351P/M** and one for the **RG351V**! 
+
+            **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)**
+
+          files: |
+            release/aarch64/RG351P/*
+            release/aarch64/RG351V/*
+          prerelease: true
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -1,0 +1,58 @@
+
+# The purpose of this build is to allow a 'beta' release be created.
+#  Typically, it will be created every day if there are new commits since the last tag (beta)
+#  It can also be run manually.
+name: release-beta
+on:
+  schedule:
+    - cron:  '0 20 * * *'
+  workflow_dispatch:  # allows manual runs
+    
+jobs:
+  launch-beta-release-if-needed:
+      runs-on: ubuntu-20.04
+      steps:
+        #- uses: hmarr/debug-action@v2
+        #  name: debug
+        - uses: actions/checkout@v2
+          name: checkout
+          with:
+            clean: false
+            fetch-depth: 0
+            
+        # We get the full name from git here as in the case of 'cron', it is not available on the event
+        - name: repository full name
+          id: full_name
+          run: |
+               echo "::set-output name=full_name::$(git config --get remote.origin.url | sed 's|^.*github.com/||g' | sed 's/.git$//g')"
+        
+        - name: changes
+          id: changes
+          run: |
+              echo "::set-output name=changes::$(git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline | wc -l)"
+              
+              release_notes="$(git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline)"
+
+              # The below lines translate linebreaks so they can be set into the 'release_notes' variable
+              release_notes="${release_notes//'%'/'%25'}"
+              release_notes="${release_notes//$'\n'/'%0A'}"
+              release_notes="${release_notes//$'\r'/'%0D'}"
+              
+              echo "::set-output name=release_notes::${release_notes}"
+        - name: Get date for artifacts
+          id: date
+          run: echo "::set-output name=date::$(date +'%Y%m%d_%H%M')"
+  
+        - name: Repository Dispatch
+          if: steps.changes.outputs.changes != '0'
+          uses: peter-evans/repository-dispatch@v1
+          with:
+            token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+            repository: ${{ steps.full_name.outputs.full_name }}
+            event-type: release-beta
+            client-payload: |
+               {
+                 "release_tag" : "beta-${{steps.date.outputs.date}}",
+                 "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
+               }
+            

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -1,0 +1,55 @@
+
+# The purpose of this build is to allow a 'draft' release be created with the correct version, etc.
+# 
+#  This 'draft' release can be used as the basis for the 'real' release.
+#  NOTE: The draft is also marked as 'prerelease' so it can be rolled out to the 'beta' channel if desired.
+name: release-draft
+on:
+  workflow_dispatch:  # allows manual runs
+    inputs:
+      release_tag:
+        description: Tag to release (ex: 20210603 - defaults to today)
+        required: false
+      release_name:
+        description: Name to use for release (ex: Crazy Hedgehog)
+        required: false
+        default: RELEASE_NAME
+    
+jobs:
+  commits:
+      runs-on: ubuntu-20.04
+      steps:
+        - uses: actions/checkout@v2
+          name: checkout
+          with:
+            clean: false
+            fetch-depth: 0
+        - name: changes
+          id: changes
+          run: |
+              previous_tag=$(git describe --tags --abbrev=0  --match "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]" --match "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9]" )
+              echo "::set-output name=changes::$(git log ${previous_tag}..HEAD --no-merges --oneline|wc -l)"
+        - name: Get date for artifacts
+          id: date
+          run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        - name: Version
+          id: version
+          run: |
+             if [[ "${{github.event.inputs.release_tag}}" != "" ]]; then
+               echo "::set-output name=version::${{github.event.inputs.release_tag}}"
+             else
+               echo "::set-output name=version::$(date +'%Y%m%d')"
+             fi
+        - name: Repository Dispatch
+          if: steps.changes.outputs.changes != '0'
+          uses: peter-evans/repository-dispatch@v1
+          with:
+            token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+            repository: ${{ github.event.repository.full_name }}
+            event-type: release-draft
+            client-payload: |
+               { 
+                 "release_tag" : "${{steps.version.outputs.version}}",
+                 "release_name" : "${{github.events.inputs.release_name}}"
+               }
+            

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="df41f163f6a6f2619f9dfade613d43c6ddeb7ae8"
+PKG_VERSION="fb2ac69fc1e56ba1bd18835487dca0d3fad2ff44"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
**tl;dr**: Beta builds will be built every day (if there are commits).  You can use online updates to update to them.  They will be 'prereleases' in GitHub so they are very similar to existing releases.


# Summary
**Beta Releases**: Creates 'beta' builds that will be created each night if a commits have been added to `main`.  

These beta builds can be 'online' updated by using the 'beta' channel.  This will allow testing online updates before having a real release and also get user feedback earlier from 'beta' users.

The `beta` builds are 'prereleases' in GitHub.  This means they can be downloaded/installed/upgraded manually in the same way as a normal release.  

**NOTE**: These 'prereleases' will create some additional 'noise' in Github notifications ("a pre-release has been published"), but it should be a maximum of once per day and 'prereleases' are not displayed on the main 351elec GitHub page so it should not be too confusing for the users.

**'Draft' Release creation**:  This change is designed to make it easier for the 351ELEC team to create releases.  

A 'draft release' build can be triggered with a proper tag (`20210603`) and name (`Crazy Hedgehog`) and the build server will: build that release, create a 'Draft' release in GitHub with the correct artifacts and skeleton of Release Notes/Download Links and the proper tag setup (the tag in git will not be created until publish).

After a draft release is created, a 351ELEC team member can then fill out the releases notes and 'publish'.  

NOTE: The draft release is also marked 'prerelease'.  This is so if the release is published, only the 'beta' channel will get the release until the 'prerelease' checkbox is unchecked.  That is not required.

# Details
- **Build Timing**: Beta builds will be run every day at 20:00  UTC.  This just basically seemed like a good time where most European/US-based team members will be awake.  We can adjust as needed.
- **Upgrade Logic Changes**: There were some small changes to the 'upgrade' scripts to ensure:
  - The new 'beta' version format `beta-20210714_1022 (beta-YYYYmmdd_hhmm)` is considered valid and will be used to compare if you can update to a newer 'beta'.  
  - If you are on the 'release' channel, *any* release will be considered an upgrade if you are on a `beta`.  This means you can switch back from 'beta' to 'release' easily even though it is likely a 'downgrade'.
  - Pulls in an upstream batocera emulation station change to tell the user the version they will upgrade to.  This is helpful when switching channels.
- **Github environment variable change needed** - In order to make this work, a new secret in 351ELEC's github will need to be created.  It is called `TRIGGER_BUILD_TOKEN` and is used to trigger the existing `main` build.  This is sort of a pain to have to require, but it appears the cleanest way to separate this build logic with GitHub actions.

# Examples
- Prerelease: https://github.com/pkegg/351ELEC/releases/tag/beta-20210714_2259
- Draft published as a release: https://github.com/pkegg/351ELEC/releases/tag/20210714