### PR TITLE
Minimum Brightness - Quick Fix

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:  # allows manual runs
     inputs:
       release_tag:
-        description: Tag to release (ex: 20210603 - defaults to today)
+        description: "Tag to release (ex: 20210603 - defaults to today)"
         required: false
       release_name:
-        description: Name to use for release (ex: Crazy Hedgehog)
+        description: "Name to use for release (ex: Crazy Hedgehog)"
         required: false
         default: RELEASE_NAME
     

--- a/packages/351elec/sources/scripts/brightness
+++ b/packages/351elec/sources/scripts/brightness
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2020-present Fewtarius
 
-MIN=0
+MIN=12
 MAX=255
 STEP=3
 


### PR DESCRIPTION
# Summary
Just a quick fix to ensure that the Fn + Vol down/up hotkeys on the V (and L3+L/R hotkey) respect the same 'minimum brightness' as ES (12).

Eventually - I would like to look at a better fix for minimum brightness - but this is just a stop gap for now to ensure users don't get stuck with the brightness all the way down (black screen).

### Other change
- I fixed the invalid YAML in the 'release-draft' manual build.  I made some changes for better documentation while preparing the 'beta-builds' PR and didn't realize it caused some errors.  Ex (you need 351ELEC permissions to view this):  https://github.com/351ELEC/351ELEC/actions/workflows/release-draft.yaml