### PR TITLE
Beta Release Notes - Encourage Stable Release

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -80,6 +80,12 @@ jobs:
         with:
           tag_name: "${{ steps.version.outputs.version }}"
           body: |
+          
+            # Latest Stable Release
+            **You probably want the [latest stable release](https://github.com/${{ github.event.repository.full_name }}/releases/tag/${{ github.event.client_payload.previous_release_tag }})**!  If you are unsure what release to choose, please use the **latest stable release.**
+
+            If you want the latest **beta** release (unstable, but absolutely latest software).  Keep reading.
+            
             # Release Notes (Beta)
             This is a pre-release based on the commit: ${{github.sha}}.
     

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -39,6 +39,10 @@ jobs:
               release_notes="${release_notes//$'\r'/'%0D'}"
               
               echo "::set-output name=release_notes::${release_notes}"
+              
+              previous_release_tag=$(git describe --tags --abbrev=0  --match "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]" --match "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9]" )
+              echo "::set-output name=previous_release_tag::${previous_release_tag}"
+
         - name: Get date for artifacts
           id: date
           run: echo "::set-output name=date::$(date +'%Y%m%d_%H%M')"
@@ -53,6 +57,7 @@ jobs:
             client-payload: |
                {
                  "release_tag" : "beta-${{steps.date.outputs.date}}",
+                 "previous_release_tag": "${{steps.changes.outputs.previous_release_tag}}",
                  "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
                }
             


### PR DESCRIPTION
## Problem
Using github pre-relases for our `beta` releases means the 'real' latest release (Crazy Hedgehog) gets buried on the [releases](https://github.com/351ELEC/351ELEC/releases/) page.  NOTE: The main 351ELEC page still has the correct link.

Since many places link directly to 'releases' page, this can be confusing for users just looking for the latest release.

## Fix
This just makes it so that every beta release will automatically include a section at the beginning to link to the latest stable release.  

This `latest stable release` link is generated by having git look for a tag matching: `YYYYMMDD` or `YYYMMDD-#` (hotfix).

# Examples
- Example release from `pkegg` repo - note that it doesn't include artifacts - but just shows how text will look: https://github.com/pkegg/351ELEC/releases/tag/beta-20210718_0454