### PR TITLE
Move Beta Builds to 351ELEC-beta

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -76,14 +76,14 @@ jobs:
             release/aarch64/RG351P/
       - name: Create pre-release
         if: github.event.action == 'release-beta'
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: "${{ steps.version.outputs.version }}"
+          tag: "${{ steps.version.outputs.version }}"
           body: |
             # Release Notes (Beta)
-            This is a pre-release based on the commit: ${{github.sha}}.
+            This is a pre-release based on the commit: ${{ github.event.repository.full_name }}@${{github.sha}}.
     
-            Beta releases are unstable and provided for the community.  Please DO NOT open issues on this build and instead post in the `#contribution-help` section of discord.
+            Beta releases are unstable and provided for the community to test fixes and explore new functionality.  Please DO NOT open issues on this build and instead post in the `#contribution-help` section of discord.
             
             See the [wiki](https://github.com/${{ github.event.repository.full_name }}/wiki/Contributing-to-351ELEC#]) for more info.
             
@@ -96,15 +96,14 @@ jobs:
              **IMPORTANT NOTE**: There are **two different images** below, one for the **RG351P/M** and one for the **RG351V**! 
 
             **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
-            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)**
-            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)**
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)**
 
-          files: |
-            release/aarch64/RG351P/*
-            release/aarch64/RG351V/*
+          artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*"
           prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+          repo: 351ELEC-beta
+
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         if: github.event.action == 'release-draft'

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -29,15 +29,15 @@ jobs:
         - name: changes
           id: changes
           run: |
-              echo "::set-output name=changes::$(git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline | wc -l)"
-              
-              release_notes="$(git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline)"
+              echo "::set-output name=changes::$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | wc -l)"
 
+              release_notes="$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | sed 's|^|${{ steps.full_name.outputs.full_name }}@|g')"
+              
               # The below lines translate linebreaks so they can be set into the 'release_notes' variable
               release_notes="${release_notes//'%'/'%25'}"
               release_notes="${release_notes//$'\n'/'%0A'}"
               release_notes="${release_notes//$'\r'/'%0D'}"
-              
+
               echo "::set-output name=release_notes::${release_notes}"
         - name: Get date for artifacts
           id: date

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -16,7 +16,11 @@ fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
-  REPO=351ELEC
+  if [ "$BAND" == "beta" ]; then
+    REPO=351ELEC-beta
+  else
+    REPO=351ELEC
+  fi
 fi
 
 FORCE=$(get_ee_setting updates.force)

--- a/packages/351elec/sources/scripts/updatecheck
+++ b/packages/351elec/sources/scripts/updatecheck
@@ -7,12 +7,16 @@ DIR=$(realpath $(dirname $0))
 BAND=$(get_ee_setting updates.type)
 ORG=$(get_ee_setting updates.github.org)
 if [ "$ORG" == "" ]; then
-  ORG="351ELEC"
+  ORG=351ELEC
 fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
-  REPO=351ELEC
+  if [ "$BAND" == "beta" ]; then
+    REPO=351ELEC-beta
+  else
+    REPO=351ELEC
+  fi
 fi
 
 FORCE=$(get_ee_setting updates.force)


### PR DESCRIPTION
# Summary
- Move the beta builds to the [351ELEC-beta](https://github.com/351ELEC/351ELEC-beta) repository.  This will ensure the beta releases do not clutter up the normal 'releases' page.
- Update the 'beta' channel in online updates to pull from `351ELEC-beta` repo.
- This changes means the 'beta' channel will never get the 'released' version from 351ELEC unless we manually publish it.  Given there will still be a 'beta' release that matches the 351EC release, I think that's fine (and actually might be less confusing)

# Upgrading from a previous beta
Though it is probably easiest to just put a new beta tar in the `updates` folder and update from an old beta manually, it is **possible**, with some manual steps, to update from the RG351 device running one of the previous betas to the new beta.  This is *not* possible from the latest stable release.  The steps involve setting developer options, so use at your own risk.

Process:
- In emulation station, press `start` -> `EmulationStation Settings` -> `Developer` -> `Updates` -> `Github Repo` and set it to `351ELEC-beta`.  This must match case, exactly, etc.
- Back on the main menu, go to `Updates & Downloads` and select `Start Update`.  This should update your as normal.
- After updating, make sure to release the `Github Repo` back to "" (blank) under developer settings otherwise it will break your `releases` channel (it will attempt to look for releases in `351ELEC-beta` which won't have any releases).

# Technical Details
- Needed to switch to the `ncipollo/release-action@v1` release action as the existing github action didn't seem to work to publish to a different repo.
  -  Not included - but in the future we should probably switch the 'draft-release' functionality to that action as well for consistency.  Since draft releases publish to the 351ELEC org (in preparation for a real release), it's not required to switch.
- Included 'merge' commits in the release notes for the beta releases as there's no real reason to shorten them and it actually makes it easier to find all the PRs.
- Also needed to prepend the `351ELEC/351ELEC@` to any git SHA's (release notes) as they are not in the current repository. 

# Examples
- https://github.com/pkegg/351ELEC-beta/releases