### PR TITLE
Fix error deleting themes in RG351

### DIFF
--- a/packages/351elec/sources/scripts/batocera-es-theme
+++ b/packages/351elec/sources/scripts/batocera-es-theme
@@ -153,21 +153,34 @@ function install_theme() {
 ###############################
 #
 function remove_theme() {
-	theme="$1"
-	success_removed=0
-		gitname=$theme
-		if [ -d "${CONFIGDIR}/${gitname}" ]; then
-		       	rm -rf "$CONFIGDIR"/"$gitname" && success_removed=1
-		else
-			echo "Theme $theme doesn't appear to be in $CONFIGDIR/$gitname"
-		fi
-	if [ "$success_removed" == 1 ]; then
-		TERMINAL=0 && echo "Theme ${theme^^} uninstalled >>>100"
-		exit 0
-	else
-		echo "Error - theme $theme could not be removed"
-		exit 1
-	fi
+        theme="$1"
+        success_removed=0
+        fn=$(date +"%s")
+        tmp="/tmp/themes_$fn"
+        if [ -f $LOCALTHEMESLIST ]; then
+                cp -f "$LOCALTHEMESLIST" "$tmp"
+        else
+                curl -sfL "$THEMESLIST" -o "$tmp" || exit 1
+        fi
+        while IFS=$' \t' read name url ; do
+                [ x"$name" != x"$theme" ] && continue
+				#There are some weird control characters we need to strip
+				url=$(echo -n "${url//[[:space:]]/}")
+                gitname=$(git_name "$url")
+                if [ -d "$CONFIGDIR"/"$gitname" ]; then
+                        rm -rf "$CONFIGDIR"/"$gitname" && success_removed=1
+                else
+                        echo "Theme $theme doesn't appear to be in $CONFIGDIR/$gitname"
+                fi
+        done < "$tmp"
+        rm "$tmp"
+        if [ "$success_removed" == 1 ]; then
+                echo "Theme ${theme^^} is now removed >>>100"
+                exit 0
+        else
+                echo "Error - theme $theme could not be removed"
+                exit 1
+        fi
 }
 
 #### Main loop


### PR DESCRIPTION
# Summary
- This should fix: https://github.com/351ELEC/351ELEC/issues/392

# Technical Details
- Pulled implementation of remove theme from its initial implementation in batocera - pretty sure there is no way our version ever worked.  See: https://github.com/batocera-linux/batocera.linux/commit/7471dcd9dbbb54f2ca83296a9ec0942951cee4cc#diff-d3e047f131829aa1b871f351c22559f6c9f68e8987372973ab7f7550f7c5df41
- I'm not exactly sure why there is a control character in the data we are reading, but since the data we are reading is stored on the file system, I don't think there's much we can do about it.  I figure sanitizing the url is fine anyway - so just added sanitization step.

Edit: removed `sed` change from this PR.  Did a `force push` to keep commits clean.