### PR TITLE
Set minimum brightness lower - prevent lockout on reboot

### DIFF
--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -273,6 +273,12 @@ if [[ ! "${BRIGHTNESS}" =~ [0-9] ]]
 then
   BRIGHTNESS=255
 fi
+
+# Ensure user doesn't get "locked out" with super low brightness
+if [[ "${BRIGHTNESS}" -lt "12" ]]
+then
+  BRIGHTNESS=12
+fi
 BRIGHTNESS=$(printf "%.0f" ${BRIGHTNESS})
 echo ${BRIGHTNESS} > /sys/class/backlight/backlight/brightness
 set_ee_setting system.brightness ${BRIGHTNESS}

--- a/packages/351elec/sources/scripts/brightness
+++ b/packages/351elec/sources/scripts/brightness
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2020-present Fewtarius
 
-MIN=12
+MIN=3
 MAX=255
 STEP=3
 
@@ -21,10 +21,9 @@ fi
 stepUp() {
   getBrightness
   MYBRIGHTNESS=$?
-  if (( ${MYBRIGHTNESS} < ${MAX} ))
+  NEWBRIGHTNESS=$((${MYBRIGHTNESS}+${STEP}))
+  if (( ${NEWBRIGHTNESS} > ${MAX} ))
   then
-    NEWBRIGHTNESS=$((${MYBRIGHTNESS}+${STEP}))
-  else
     NEWBRIGHTNESS=${MAX}
   fi
   echo "${NEWBRIGHTNESS}" > /sys/class/backlight/backlight/brightness
@@ -34,16 +33,14 @@ stepUp() {
 stepDown() {
   getBrightness
   MYBRIGHTNESS=$?
-  if (( ${MYBRIGHTNESS} > ${MIN} ))
+  NEWBRIGHTNESS=$((${MYBRIGHTNESS}-${STEP}))
+  if (( ${NEWBRIGHTNESS} < ${MIN} ))
   then
-    NEWBRIGHTNESS=$((${MYBRIGHTNESS}-${STEP}))
-  else
     NEWBRIGHTNESS=${MIN}
   fi
   echo "${NEWBRIGHTNESS}" > /sys/class/backlight/backlight/brightness
   set_ee_setting system.brightness ${NEWBRIGHTNESS}
 }
-
 getBrightness() {
   local BRIGHTNESS=$(cat /sys/class/backlight/backlight/brightness)
   return ${BRIGHTNESS}

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="fb2ac69fc1e56ba1bd18835487dca0d3fad2ff44"
+PKG_VERSION="22a5add6a2a7d17461693ef45a6bd3c608e6305b"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
**Edit**: This is ready to merge.

# Summary
Set the minimum brightness lower.  

We now allow going down to `1/100` from the previous minimum of `5/100` brightness.  This should be still bright enough that most displays won't turn off.

However, some displays will be dark at these brightness levels.  If the display *does* turn off at these low brightnesses, it is possible to get **locked out** (where you can't see the screen to do anything - including turn up the brightness).  On the V, you can now just do `Fn + Vol Up` or on the P/V you can do L3+R1, but users may not know the hotkeys.

To prevent this lock out, on boot we now set the minimum brightness to the old minimum (5/100) if you are below the old minimum brightness.  This means that if a user gets locked out by this new lower brightness, they just reboot and should be fine.  This also means that user wanting this new lower brightness will need to set it that low after each reboot, but given the 'use case' for this is a pitch black room (and hotkeys work to easily adjust), that should be fine.

# Technical Details
- The brightness level is actually out of 255, not 100.  The new minimum brightness is 3/255 and the old minimum brightness was: 12/255.  Emulation Station converts from 100.