### PR TITLE
Enable resolution configuration for retrorun (n64)

### DIFF
--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -36,7 +36,7 @@ fi
 rm /dev/input/by-path/platform-odroidgo2-joypad-event-joystick || true
 echo 'creating fake joypad'
 /usr/bin/rg351p-js2xbox --silent -t oga_joypad &
-sleep 1
+
 echo 'confguring inputs'
 EE_DEVICE=$(cat /storage/.config/.OS_ARCH)
 echo 'confguring inputs on device:'$EE_DEVICE
@@ -47,7 +47,7 @@ else
 	ln -s /dev/input/event3 /dev/input/by-path/platform-odroidgo2-joypad-event-joystick
 fi
 chmod 777 /dev/input/by-path/platform-odroidgo2-joypad-event-joystick
-sleep 1
+
 echo 'using core:' "$1"
 echo 'platform:' "$3"
 echo 'starting game:' "$2"
@@ -58,7 +58,7 @@ then
     echo 'enabling FPS in the logs'
     FPS="-f"
 fi
-sleep 1
+
 if [[ "$1" =~ "pcsx_rearmed" ]] || [[ "$1" =~ "parallel_n64" ]] || [[ "$1" =~ "uae4arm" ]]
 then
     echo 'using 32bit'
@@ -68,7 +68,7 @@ else
 	echo 'using 64bit'
 	/usr/bin/retrorun --triggers $FPS -n -s /storage/roms/"$3" -d /roms/bios "$1" "$2"
 fi
-sleep 1
+
 rm /dev/input/by-path/platform-odroidgo2-joypad-event-joystick
 kill $(pidof rg351p-js2xbox)
 echo 'end!'

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -3,6 +3,36 @@ echo 'starting retrorun emulator...'
 if [ ! -f /storage/.config/distribution/configs/retrorun.cfg ]; then
   cp -f /usr/config/distribution/configs/retrorun.cfg /storage/.config/distribution/configs/
 fi
+CORE="$1"
+ROM="$2"
+PLATFORM="$3"
+
+retrorun_config_file="/storage/.config/distribution/configs/retrorun.cfg"
+
+source /etc/profile
+rom_name=$(basename "${ROM}")
+resolution=$(get_ee_setting resolution "${PLATFORM}" "${rom_name}")
+
+echo "resolution: ${resolution} rom: ${rom_name}"
+
+# Because the config file is on the SD card, we are careful to only write when needed
+if [ "$resolution" != "" ]; then
+  if ! grep "^parallel-n64-screensize = ${resolution}" "${retrorun_config_file}"; then
+    echo "Updating resolution..." 
+    sed -i "/^parallel-n64-screensize/d" ${retrorun_config_file}
+    echo "parallel-n64-screensize = ${resolution}" >> ${retrorun_config_file}
+  else
+    echo "resolution already correct"
+  fi
+else
+  if grep "^parallel-n64-screensize =" ${retrorun_config_file}; then
+    echo "Updating resolution..."
+    sed -i "/^parallel-n64-screensize/d" ${retrorun_config_file}
+  else
+    echo "resolution already correct"
+  fi
+fi
+
 rm /dev/input/by-path/platform-odroidgo2-joypad-event-joystick || true
 echo 'creating fake joypad'
 /usr/bin/rg351p-js2xbox --silent -t oga_joypad &

--- a/packages/ui/351elec-emulationstation/config/es_features.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_features.cfg
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <features>
+  <emulator name="retrorun">
+    <cores>
+      <core name="parallel_n64" features="">
+        <features>
+        <feature name="resolution">
+          <choice name="640x480" value="640x480" />
+          <choice name="320x240" value="320x240" />
+        </feature>
+        </features>
+      </core>
+      <core name="parallel_n64_gln64" features="">
+        <features>
+        <feature name="resolution">
+          <choice name="640x480" value="640x480" />
+          <!--<choice name="320x240" value="320x240" />-->
+        </feature>
+        </features>
+      </core>
+    </cores>
+  </emulator>
   <emulator name="libretro" features="videomode, ratio, smooth, shaders, pixel_perfect, latency_reduction, game_translation">
     <cores>
       <core name="2048" features="netplay, rewind, autosave" />


### PR DESCRIPTION
# Summary
Make retrorun resolution configurable for n64 in Emulation Station (option is called `resolution`).  Gives only one option: `640x480` for `n64_parallel_gln64` and both: `320x240` and `640x480` for `n64_parallel`.  NOTE: that until retrorun is updated, 320x240 is broken on the RG351V.

Because the retrorun.cfg file resides on the SD card, this change checks if updating the file is needed before writing to the config file to avoid unnecessary wear on the SD card.

# Current issues 
I believe these will be addressed when we pull in dhwz's branch, so not planning to fix here.  I can look at addressing here if need be.

- Parallel n64 core does not run on V in 320x240 (`auto`) mode. Currently, you must configure resolution to `640x480`.  New update of retrorun (in dhwz branch) fixes this I believe.
- `/storage/.config/emulationstation/es_features.cfg` is not updated from `/usr/config` on upgrade.  
  - This means you will need to *manually* do the following command (via ssh) right now to see new n64 resolution option: `cp /usr/config/emulationstation/es_features.cfg /storage/.config/emulationstation/`