### PR TITLE
Patch for analog sensitivity

### DIFF
--- a/projects/Rockchip/devices/RG351P/packages/linux/patches/05-osh-pb-controller.patch
+++ b/projects/Rockchip/devices/RG351P/packages/linux/patches/05-osh-pb-controller.patch
@@ -1,0 +1,95 @@
+diff --git a/drivers/input/evdev.c b/drivers/input/evdev.c
+index e9ae3d500..506d148dd 100644
+--- a/drivers/input/evdev.c
++++ b/drivers/input/evdev.c
+@@ -15,6 +15,15 @@
+ #define EVDEV_MIN_BUFFER_SIZE	64U
+ #define EVDEV_BUF_PACKETS	8
+ 
++#define RG351P_ABS_Z_MIN 500
++#define RG351P_ABS_Z_MAX 3500
++#define RG351P_ABS_RY_MIN 500
++#define RG351P_ABS_RY_MAX 3500
++#define RG351P_ABS_RX_MIN 500
++#define RG351P_ABS_RX_MAX 3200
++#define RG351P_ABS_RZ_MIN 500
++#define RG351P_ABS_RZ_MAX 3200
++
+ #include <linux/poll.h>
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+@@ -808,7 +817,7 @@ static int handle_eviocgbit(struct input_dev *dev,
+ 			    void __user *p, int compat_mode)
+ {
+ 	unsigned long *bits;
+-	int len;
++	int len, nr;
+ 
+ 	switch (type) {
+ 
+@@ -824,6 +833,35 @@ static int handle_eviocgbit(struct input_dev *dev,
+ 	default: return -EINVAL;
+ 	}
+ 
++	// [RG351P] OpenSimHardware OSH PB Controller
++	if (dev->id.vendor == 0x1209 && dev->id.product == 0x3100) {
++		if (type == EV_KEY) {
++			for (nr = 0; nr < BTN_GAMEPAD; nr++) {
++				clear_bit(nr, bits);
++			}
++			for (nr = BTN_MODE; nr < KEY_MAX; nr++) {
++				clear_bit(nr, bits);
++			}
++		} else if (type == EV_ABS) {
++			for (nr = ABS_THROTTLE; nr <= ABS_BRAKE; nr++) {
++				clear_bit(nr, bits);
++			}
++			for (nr = ABS_HAT1X; nr <= ABS_HAT3Y; nr++) {
++				clear_bit(nr, bits);
++			}
++			dev->absinfo[ABS_Z].minimum = RG351P_ABS_Z_MIN;		// Analog1 X
++			dev->absinfo[ABS_Z].maximum = RG351P_ABS_Z_MAX;
++			dev->absinfo[ABS_RY].minimum = RG351P_ABS_RY_MIN;	// Analog2 X
++			dev->absinfo[ABS_RY].maximum = RG351P_ABS_RY_MAX;
++			dev->absinfo[ABS_RX].minimum = RG351P_ABS_RX_MIN;	// Analog1 Y
++			dev->absinfo[ABS_RX].maximum = RG351P_ABS_RX_MAX;
++			dev->absinfo[ABS_RZ].minimum = RG351P_ABS_RZ_MIN;	// Analog2 Y
++			dev->absinfo[ABS_RZ].maximum = RG351P_ABS_RZ_MAX;
++		} else if (type == EV_MSC) {
++			clear_bit(MSC_SCAN, bits);
++		}
++	}
++
+ 	return bits_to_user(bits, len, size, p, compat_mode);
+ }
+ 
+diff --git a/drivers/input/joydev.c b/drivers/input/joydev.c
+index 5d11fea3c..e45ac874e 100644
+--- a/drivers/input/joydev.c
++++ b/drivers/input/joydev.c
+@@ -601,6 +601,12 @@ static long joydev_compat_ioctl(struct file *file,
+ 		goto out;
+ 	}
+ 
++	// [RG351P] OpenSimHardware OSH PB Controller
++	if (!strcmp(joydev->handle.dev->name, "OpenSimHardware OSH PB Controller")) {
++		joydev->nabs = 8;
++		joydev->nkey = 12;
++	}
++
+ 	switch (cmd) {
+ 
+ 	case JS_SET_TIMELIMIT:
+@@ -666,6 +672,12 @@ static long joydev_ioctl(struct file *file,
+ 		goto out;
+ 	}
+ 
++	// [RG351P] OpenSimHardware OSH PB Controller
++	if (!strcmp(joydev->handle.dev->name, "OpenSimHardware OSH PB Controller")) {
++		joydev->nabs = 8;
++		joydev->nkey = 12;
++	}
++
+ 	switch (cmd) {
+ 
+ 	case JS_SET_TIMELIMIT:

--- a/projects/Rockchip/devices/RG351V/packages/linux/patches/05-osh-pb-controller.patch
+++ b/projects/Rockchip/devices/RG351V/packages/linux/patches/05-osh-pb-controller.patch
@@ -1,0 +1,95 @@
+diff --git a/drivers/input/evdev.c b/drivers/input/evdev.c
+index e9ae3d500..506d148dd 100644
+--- a/drivers/input/evdev.c
++++ b/drivers/input/evdev.c
+@@ -15,6 +15,15 @@
+ #define EVDEV_MIN_BUFFER_SIZE	64U
+ #define EVDEV_BUF_PACKETS	8
+ 
++#define RG351P_ABS_Z_MIN 500
++#define RG351P_ABS_Z_MAX 3500
++#define RG351P_ABS_RY_MIN 500
++#define RG351P_ABS_RY_MAX 3500
++#define RG351P_ABS_RX_MIN 500
++#define RG351P_ABS_RX_MAX 3200
++#define RG351P_ABS_RZ_MIN 500
++#define RG351P_ABS_RZ_MAX 3200
++
+ #include <linux/poll.h>
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+@@ -808,7 +817,7 @@ static int handle_eviocgbit(struct input_dev *dev,
+ 			    void __user *p, int compat_mode)
+ {
+ 	unsigned long *bits;
+-	int len;
++	int len, nr;
+ 
+ 	switch (type) {
+ 
+@@ -824,6 +833,35 @@ static int handle_eviocgbit(struct input_dev *dev,
+ 	default: return -EINVAL;
+ 	}
+ 
++	// [RG351P] OpenSimHardware OSH PB Controller
++	if (dev->id.vendor == 0x1209 && dev->id.product == 0x3100) {
++		if (type == EV_KEY) {
++			for (nr = 0; nr < BTN_GAMEPAD; nr++) {
++				clear_bit(nr, bits);
++			}
++			for (nr = BTN_MODE; nr < KEY_MAX; nr++) {
++				clear_bit(nr, bits);
++			}
++		} else if (type == EV_ABS) {
++			for (nr = ABS_THROTTLE; nr <= ABS_BRAKE; nr++) {
++				clear_bit(nr, bits);
++			}
++			for (nr = ABS_HAT1X; nr <= ABS_HAT3Y; nr++) {
++				clear_bit(nr, bits);
++			}
++			dev->absinfo[ABS_Z].minimum = RG351P_ABS_Z_MIN;		// Analog1 X
++			dev->absinfo[ABS_Z].maximum = RG351P_ABS_Z_MAX;
++			dev->absinfo[ABS_RY].minimum = RG351P_ABS_RY_MIN;	// Analog2 X
++			dev->absinfo[ABS_RY].maximum = RG351P_ABS_RY_MAX;
++			dev->absinfo[ABS_RX].minimum = RG351P_ABS_RX_MIN;	// Analog1 Y
++			dev->absinfo[ABS_RX].maximum = RG351P_ABS_RX_MAX;
++			dev->absinfo[ABS_RZ].minimum = RG351P_ABS_RZ_MIN;	// Analog2 Y
++			dev->absinfo[ABS_RZ].maximum = RG351P_ABS_RZ_MAX;
++		} else if (type == EV_MSC) {
++			clear_bit(MSC_SCAN, bits);
++		}
++	}
++
+ 	return bits_to_user(bits, len, size, p, compat_mode);
+ }
+ 
+diff --git a/drivers/input/joydev.c b/drivers/input/joydev.c
+index 5d11fea3c..e45ac874e 100644
+--- a/drivers/input/joydev.c
++++ b/drivers/input/joydev.c
+@@ -601,6 +601,12 @@ static long joydev_compat_ioctl(struct file *file,
+ 		goto out;
+ 	}
+ 
++	// [RG351P] OpenSimHardware OSH PB Controller
++	if (!strcmp(joydev->handle.dev->name, "OpenSimHardware OSH PB Controller")) {
++		joydev->nabs = 8;
++		joydev->nkey = 12;
++	}
++
+ 	switch (cmd) {
+ 
+ 	case JS_SET_TIMELIMIT:
+@@ -666,6 +672,12 @@ static long joydev_ioctl(struct file *file,
+ 		goto out;
+ 	}
+ 
++	// [RG351P] OpenSimHardware OSH PB Controller
++	if (!strcmp(joydev->handle.dev->name, "OpenSimHardware OSH PB Controller")) {
++		joydev->nabs = 8;
++		joydev->nkey = 12;
++	}
++
+ 	switch (cmd) {
+ 
+ 	case JS_SET_TIMELIMIT:


### PR DESCRIPTION
Patch for analog sensitivity based on https://github.com/british-choi/EmuELEC/blob/master/projects/Rockchip/packages/linux/patches/RG351V/linux-998-rg351v-osh-pb-controller.patch

-----------------------

For some reason the above patch doesn't use the same value adjustments for the V stick. Not really sure why they should be different between the P and V since they use the same type of stick, so giving it a try with the same patch for both P and V and I can switch it out if it doesn't work.