### PR TITLE
Cloud Save: get remote name and path from cloud-sync.conf

### DIFF
--- a/packages/351elec/config/distribution/modules/cloud_backup.sh
+++ b/packages/351elec/config/distribution/modules/cloud_backup.sh
@@ -3,9 +3,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Xargon (https://github.com/XargonWan)
 
+# Create rclone dir if it does not exist
+mkdir -p /storage/roms/gamedata/rclone/
+
+# Source CLOUD_SAVE_PATH and CLOUD_SAVE_REMOTE
+CLOUD_SYNC_CONFIG="/storage/roms/gamedata/rclone/cloud-sync.conf"
+if [ ! -f "$CLOUD_SYNC_CONFIG" ]; then
+    cp /usr/config/cloud-sync.conf "$CLOUD_SYNC_CONFIG"
+fi
+source "$CLOUD_SYNC_CONFIG"
+
 # If the rclone rules don't exist it will copy the default ones
 if [ ! -f /storage/roms/gamedata/rclone/cloud-sync-rules.conf ]; then
-    mkdir -p /storage/roms/gamedata/rclone/
     cp /usr/config/cloud-sync-rules.conf /storage/roms/gamedata/rclone/
 fi
 
@@ -26,7 +35,7 @@ case $response in
 
     21)
         clear > /dev/console
-        rclone sync /storage/roms/ 351remote:/351backup/ --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
+        rclone sync /storage/roms/ "$CLOUD_SAVE_REMOTE":"$CLOUD_SAVE_PATH" --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
         text_viewer -m "Backup completed!" -t "351ELEC Cloud Save Backup"
         ;;
 esac

--- a/packages/351elec/config/distribution/modules/cloud_backup.sh
+++ b/packages/351elec/config/distribution/modules/cloud_backup.sh
@@ -6,7 +6,7 @@
 # Create rclone dir if it does not exist
 mkdir -p /storage/roms/gamedata/rclone/
 
-# Source CLOUD_SAVE_PATH and CLOUD_SAVE_REMOTE
+# Source CLOUD_SYNC_PATH and CLOUD_SYNC_REMOTE
 CLOUD_SYNC_CONFIG="/storage/roms/gamedata/rclone/cloud-sync.conf"
 if [ ! -f "$CLOUD_SYNC_CONFIG" ]; then
     cp /usr/config/cloud-sync.conf "$CLOUD_SYNC_CONFIG"
@@ -35,7 +35,7 @@ case $response in
 
     21)
         clear > /dev/console
-        rclone sync /storage/roms/ "$CLOUD_SAVE_REMOTE":"$CLOUD_SAVE_PATH" --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
+        rclone sync /storage/roms/ "$CLOUD_SYNC_REMOTE":"$CLOUD_SYNC_PATH" --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
         text_viewer -m "Backup completed!" -t "351ELEC Cloud Save Backup"
         ;;
 esac

--- a/packages/351elec/config/distribution/modules/cloud_restore.sh
+++ b/packages/351elec/config/distribution/modules/cloud_restore.sh
@@ -6,7 +6,7 @@
 # Create rclone dir if it does not exist
 mkdir -p /storage/roms/gamedata/rclone/
 
-# Source CLOUD_SAVE_PATH and CLOUD_SAVE_REMOTE
+# Source CLOUD_SYNC_PATH and CLOUD_SYNC_REMOTE
 CLOUD_SYNC_CONFIG="/storage/roms/gamedata/rclone/cloud-sync.conf"
 if [ ! -f "$CLOUD_SYNC_CONFIG" ]; then
     cp /usr/config/cloud-sync.conf "$CLOUD_SYNC_CONFIG"
@@ -35,7 +35,7 @@ case $response in
 
     21)
         clear > /dev/console
-        rclone sync "$CLOUD_SAVE_REMOTE":"$CLOUD_SAVE_PATH" /storage/roms/ --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
+        rclone sync "$CLOUD_SYNC_REMOTE":"$CLOUD_SYNC_PATH" /storage/roms/ --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
         text_viewer -m "Backup restored!" -t "351ELEC Cloud Save Restore"
         ;;
 esac

--- a/packages/351elec/config/distribution/modules/cloud_restore.sh
+++ b/packages/351elec/config/distribution/modules/cloud_restore.sh
@@ -3,9 +3,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Xargon (https://github.com/XargonWan)
 
+# Create rclone dir if it does not exist
+mkdir -p /storage/roms/gamedata/rclone/
+
+# Source CLOUD_SAVE_PATH and CLOUD_SAVE_REMOTE
+CLOUD_SYNC_CONFIG="/storage/roms/gamedata/rclone/cloud-sync.conf"
+if [ ! -f "$CLOUD_SYNC_CONFIG" ]; then
+    cp /usr/config/cloud-sync.conf "$CLOUD_SYNC_CONFIG"
+fi
+source "$CLOUD_SYNC_CONFIG"
+
 # If the rclone rules don't exist it will copy the default ones
 if [ ! -f /storage/roms/gamedata/rclone/cloud-sync-rules.conf ]; then
-    mkdir -p /storage/roms/gamedata/rclone/
     cp /usr/config/cloud-sync-rules.conf /storage/roms/gamedata/rclone/
 fi
 
@@ -26,7 +35,7 @@ case $response in
 
     21)
         clear > /dev/console
-        rclone sync 351remote:/351backup/ /storage/roms/ --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
+        rclone sync "$CLOUD_SAVE_REMOTE":"$CLOUD_SAVE_PATH" /storage/roms/ --filter-from /roms/gamedata/rclone/cloud-sync-rules.conf -P --config /roms/gamedata/rclone/rclone.conf --log-level DEBUG --log-file /tmp/logs/cloud-sync.log 2>&1 > /dev/console
         text_viewer -m "Backup restored!" -t "351ELEC Cloud Save Restore"
         ;;
 esac

--- a/packages/sysutils/rclone/cloud-sync.conf
+++ b/packages/sysutils/rclone/cloud-sync.conf
@@ -1,5 +1,5 @@
-# CLOUD_SAVE_PATH is where files on the remote go. For S3 this includes the bucket name.
-CLOUD_SAVE_PATH="/351remote/"
+# CLOUD_SYNC_PATH is where files on the remote go. For S3 this includes the bucket name.
+CLOUD_SYNC_PATH="/351remote/"
 
-# CLOUD_SAVE_REMOTE must match the remote name in rclone.conf
+# CLOUD_SYNC_REMOTE must match the remote name in rclone.conf
 CLOUD_SYNC_REMOTE="351backup"

--- a/packages/sysutils/rclone/cloud-sync.conf
+++ b/packages/sysutils/rclone/cloud-sync.conf
@@ -1,0 +1,5 @@
+# CLOUD_SAVE_PATH is where files on the remote go. For S3 this includes the bucket name.
+CLOUD_SAVE_PATH="/351remote/"
+
+# CLOUD_SAVE_REMOTE must match the remote name in rclone.conf
+CLOUD_SYNC_REMOTE="351backup"


### PR DESCRIPTION
By default, Cloud Saves try to use the rclone remote name `351remote` and path `/351remote/`

This can be overridden by editing the values in `/storage/roms/gamedata/rclone/cloud-sync.conf`.