### PR TITLE
Add podman support for building in addition to docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ docker-%: PWD := $(shell pwd)
 docker-%: DOCKER_CMD:= $(shell if which docker 2>/dev/null 1>/dev/null; then echo "docker"; elif which podman 2>/dev/null 1>/dev/null; then echo "podman"; fi)
 
 # Podman requires some extra args (`--userns=keep-id` and `--security-opt=label=disable`).  Set those args if using podman 
-docker-%: PODMAN_ARGS:= $(shell if ! which docker 2>/dev/null 1>/dev/null && which podman 2> /dev/null 1> /dev/null; then echo "--userns=keep-id --security-opt=label=disable"; fi)
+docker-%: PODMAN_ARGS:= $(shell if ! which docker 2>/dev/null 1>/dev/null && which podman 2> /dev/null 1> /dev/null; then echo "--userns=keep-id --security-opt=label=disable -v /proc/mounts:/etc/mtab"; fi)
 
 # Use 'sudo' if docker ps doesn't work.  In theory, other things than missing sudo could cause this.  But sudo needed is a common issue and easy to fix.
 docker-%: SUDO := $(shell if which docker 2> /dev/null 1> /dev/null && ! docker ps -q 2> /dev/null 1> /dev/null ; then echo "sudo"; fi)

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,14 @@ docker-%: GID := $(shell id -g)
 # PWD is 'present working directory' and passes through the full path to current dir to docker (becomes 'work')
 docker-%: PWD := $(shell pwd)
 
+# Command to use (either `docker` or `podman`)
+docker-%: DOCKER_CMD:= $(shell if which docker 2>/dev/null 1>/dev/null; then echo "docker"; elif which podman 2>/dev/null 1>/dev/null; then echo "podman"; fi)
+
+# Podman requires some extra args (`--userns=keep-id` and `--security-opt=label=disable`).  Set those args if using podman 
+docker-%: PODMAN_ARGS:= $(shell if ! which docker 2>/dev/null 1>/dev/null && which podman 2> /dev/null 1> /dev/null; then echo "--userns=keep-id --security-opt=label=disable"; fi)
+
 # Use 'sudo' if docker ps doesn't work.  In theory, other things than missing sudo could cause this.  But sudo needed is a common issue and easy to fix.
-docker-%: SUDO := $(shell if ! docker ps -q 2> /dev/null 1> /dev/null; then echo "sudo"; fi)
+docker-%: SUDO := $(shell if which docker 2> /dev/null 1> /dev/null && ! docker ps -q 2> /dev/null 1> /dev/null ; then echo "sudo"; fi)
 
 # Launch docker as interactive if this is an interactive shell (allows ctrl-c for manual and running non-interactive - aka: build server)
 docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")
@@ -80,25 +86,27 @@ docker-%: INTERACTIVE=$(shell [ -t 0 ] && echo "-it")
 docker-%: COMMAND=make $*
 
 # Get .env file ready
-docker-%: $(shell env > .env)
+docker-%: $(shell env | grep "=" > .env)
 
 # If the user issues a `make docker-shell` just start up bash as the shell to run commands
 docker-shell: COMMAND=bash
 
 # Command: builds docker image locally from Dockerfile
 docker-image-build:
-	$(SUDO) docker build . -t $(DOCKER_IMAGE)
+	$(SUDO) $(DOCKER_CMD) build . -t $(DOCKER_IMAGE)
+
 # Command: pulls latest docker image from dockerhub.  This will *replace* locally built version.
 docker-image-pull:
-	$(SUDO) docker pull $(DOCKER_IMAGE)
+	$(SUDO) $(DOCKER_CMD) pull $(DOCKER_IMAGE)
 
 # Command: pushes the latest Docker image to dockerhub.  This is *not* needed to build. It updates the latest build image in dockerhub for everyone.
 # Only 351elec admins in dockerhub can do this.
 #
 # You must login with: docker login --username <username> and provide either a password or token (from user settings -> security in dockerhub) before this will work.
 docker-image-push:
-	$(SUDO) docker push $(DOCKER_IMAGE)
+	$(SUDO) $(DOCKER_CMD) push $(DOCKER_IMAGE)
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:
-	$(SUDO) docker run $(INTERACTIVE) --env-file .env --rm --user $(UID):$(GID) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
+	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --env-file .env --rm --user $(UID):$(GID) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
+


### PR DESCRIPTION
# Summary
This PR adds support for building with [podman](https://podman.io/) in addition to `docker`.  Podman enables easier use without `root` access and allows support for platforms like Fedora 32 which do not have official docker support anymore.

## Using
Install podman and ensure docker is **not** installed.  All `make docker-*` commands should work as normal.

## Logic
- If docker exists, use docker to build.  If docker does not exist and podman does, use podman.
- If using podman, we do not use `sudo` (as podman is designed to not require root).  There may be use cases for this - but seemed simpler to just avoid this.

## Technical Details
In order to properly map user permissions of files in the same way as docker, podman requires an additional argument: `--userns=keep-id`.  We automatically pass it.

In order to run when using `selinux`, the arguments `--security-opt=label=disable` are passed to podman as well.

Also pass /proc/mounts as /etc/mtab so building of squashfs works.  This works around this issue for released versions of pod man and still should work with latest version: https://github.com/containers/podman/issues/10263