### PR TITLE
Exclude .Spotlight-V100 and .Trashes from cloud sync.

### DIFF
--- a/packages/sysutils/rclone/cloud-sync-rules.conf
+++ b/packages/sysutils/rclone/cloud-sync-rules.conf
@@ -1,8 +1,7 @@
-# exclude everything
-- bios/**
-- *
+# Exclude mac folders
 - .Trashes/**
 - .Spotlight-V100/**
+
 # Main dir is /storage/roms
 # COMMONS
 + *.sav
@@ -27,3 +26,7 @@
 + *.hi
 + *.hs
 + *.fs
+
+# exclude everything
+- bios/**
+- *

--- a/packages/sysutils/rclone/cloud-sync-rules.conf
+++ b/packages/sysutils/rclone/cloud-sync-rules.conf
@@ -1,3 +1,8 @@
+# exclude everything
+- bios/**
+- *
+- .Trashes/**
+- .Spotlight-V100/**
 # Main dir is /storage/roms
 # COMMONS
 + *.sav
@@ -22,7 +27,3 @@
 + *.hi
 + *.hs
 + *.fs
-
-# exclude everything else
-- bios/**
-- *


### PR DESCRIPTION
Moved exclude rules on top to prevent files with allowed extensions from not being removed.