### PR TITLE
Solarus: Use double quotes in launch script

### DIFF
--- a/packages/games/emulators/solarus/scripts/solarus.sh
+++ b/packages/games/emulators/solarus/scripts/solarus.sh
@@ -4,6 +4,6 @@
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
 [[ ! -d "/storage/roms/gamedata/solarus/" ]] && mkdir -p "/storage/roms/gamedata/solarus/"
-solarus-run -fullscreen=yes -joypad-deadzone=32767 -quit-combo=6+7 ${1}
+solarus-run -fullscreen=yes -joypad-deadzone=32767 -quit-combo=6+7 "${1}"
 
 exit 0


### PR DESCRIPTION
The most trivial pull request ever! :D

This is needed for being able to launch Solarus games from a path that contains spaces.