### PR TITLE
Git pull - better resiliency

### DIFF
--- a/scripts/get_git
+++ b/scripts/get_git
@@ -99,8 +99,11 @@ for d in "${SOURCES}/${1}/${1}-"* ; do
         if [ "${GIT_FOUND}" = "yes" ]; then
           build_msg "CLR_GET" "GIT PULL" "${1}"
 
-          # If there is an error with 'git pull', just reclone
-          if ! git pull; then
+          # If there is an error with 'git pull' or updating the submodules, just reclone
+          # NOTE: we run the submodule update twice if the clone already
+          #       exists - but deduplicating would complicate the logic quite a lot and
+          #       the second time is almost a no-op
+          if ! git pull || ! git submodule update --init --recursive ${GIT_SUBMODULE_PARAMS}; then
               cd "${opwd}"
               build_msg "CLR_CLEAN" "DELETE" "(${d})"
               GIT_FOUND=NO

--- a/scripts/get_git
+++ b/scripts/get_git
@@ -98,7 +98,14 @@ for d in "${SOURCES}/${1}/${1}-"* ; do
         fi
         if [ "${GIT_FOUND}" = "yes" ]; then
           build_msg "CLR_GET" "GIT PULL" "${1}"
-          git pull
+
+          # If there is an error with 'git pull', just reclone
+          if ! git pull; then
+              cd "${opwd}"
+              build_msg "CLR_CLEAN" "DELETE" "(${d})"
+              GIT_FOUND=NO
+              rm -rf "${d}"
+          fi
           cd "${opwd}"
         fi
       else


### PR DESCRIPTION
# Summary
PPSSPP update showed some cases where the old git location could not be 'pulled' because there are existing ignored files in the way from the previous build.

This fix just makes it so if the git clone fails, the code just removes the git checkout of the package being built and re-clones it as though it was an initial build.

Only lightly tested - but seems to fix the ppsspp issue.

edit:  I did see one case where this may have still failed with submodules, but still worked on retry which is better than before.
