### PR TITLE
Use git clone for linux repo

### DIFF
--- a/projects/Rockchip/devices/RG351P/packages/linux/package.mk
+++ b/projects/Rockchip/devices/RG351P/packages/linux/package.mk
@@ -5,7 +5,9 @@
 
 PKG_NAME="linux"
 PKG_VERSION="c8fb373f55d3adce9c75f0b0f94c93f566cb1930"
-PKG_URL="https://github.com/351ELEC/kernel_rg351/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/351ELEC/kernel_rg351.git"
+PKG_GIT_CLONE_BRANCH="main"
+GET_HANDLER_SUPPORT="git"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kernel.org"
 PKG_DEPENDS_HOST="ccache:host openssl:host"

--- a/projects/Rockchip/devices/RG351V/packages/linux/package.mk
+++ b/projects/Rockchip/devices/RG351V/packages/linux/package.mk
@@ -5,7 +5,9 @@
 
 PKG_NAME="linux"
 PKG_VERSION="c8fb373f55d3adce9c75f0b0f94c93f566cb1930"
-PKG_URL="https://github.com/351ELEC/kernel_rg351/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/351ELEC/kernel_rg351.git"
+PKG_GIT_CLONE_BRANCH="main"
+GET_HANDLER_SUPPORT="git"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kernel.org"
 PKG_DEPENDS_HOST="ccache:host openssl:host"


### PR DESCRIPTION
# Summary
The way we currently download the linux repo from the archive means that there are a lot of ~150MB tar files which litter the sources folder.  Additionally, a new commit requires ~150MB download.

This change just switches to using a git repo.  This does have the disadvantage of the sources folder containing a full git checkout (which is something like 1GB), however, new changes will require almost no download or extra space (a `git pull` will be done) .