### PR TITLE
Allow Draft PR builds with 'build' Label

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -10,7 +10,7 @@ on:
       - '.dockerignore'
     branches:
       - main
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
 
 # Ensure that if there are multiple builds for a PR only 1 is queued
 # Example: 1st commit in PR starts a build then 2-9 commits come in during the first build.
@@ -23,7 +23,7 @@ jobs:
     # Run on self-hosted runners with the 'pr' label
     runs-on: pr
     # Don't run on drafts
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event.label.name == 'build' 
     steps:
       - uses: actions/checkout@v2
         name: checkout (pull request)


### PR DESCRIPTION
By default draft PR's are not built.  This allows a draft PR to be built if they are labeled with the label 'build'.

Sorry about previous test PR against 351elec - was trying to test against my fork and not 315elec.