### PR TITLE
Don't include .img.gz files in main builds

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -60,6 +60,13 @@ jobs:
             set -e
             rm -rf release/aarch64/RG351*/*.system*
             rm -rf release/aarch64/RG351*/*.kernel*
+      - name: Cleanup system artifacts (no .img in non-release 'main' builds)
+        if: github.event.client_payload.release_tag == ''
+        run: |
+            set -e
+            #main builds only include the .tar for speed
+            rm -rf release/aarch64/RG351*/*.img.gz*
+
       - name: Archive RG351V (${{github.sha}})
         uses: actions/upload-artifact@v2
         if: github.event.client_payload.release_tag == ''


### PR DESCRIPTION
Main builds don't really need the .img.gz and it is sort of a pain to have to download the zip which includes both.  This just removes the .img.gz from main builds.  Keeps them both for beta builds.