### PR TITLE
Beta Build - Publish release as draft during upload

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -81,7 +81,7 @@ jobs:
           name: RG351P-dev-main-${{ steps.date.outputs.date }}-${{steps.sha.outputs.sha}}
           path: |
             release/aarch64/RG351P/
-      - name: Create pre-release
+      - name: Create pre-release as draft at first to hide during uploads
         if: github.event.action == 'release-beta'
         uses: ncipollo/release-action@v1
         with:
@@ -108,9 +108,21 @@ jobs:
 
           artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*"
           prerelease: true
+          draft: true
           token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
           repo: 351ELEC-beta
-
+      - name: Switch draft to start showing release 
+        if: github.event.action == 'release-beta'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          allowUpdates: true
+          draft: false
+          prerelease: true
+          token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+          repo: 351ELEC-beta
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         if: github.event.action == 'release-draft'


### PR DESCRIPTION
# Summary
Today, the beta-release was slow to upload artifacts.  Typically, it takes less than 5 minutes, but for some reason it took well over an hour to upload.  Still investigating why - seems likely it was github being overloaded.

The issue with that is the release is published as a publicly available pre-release **whille the artifacts are being uploaded**.  This means OTA updates will find an update, but the artifact does not exist and the update will error.

# Fix
The fix is to initially publish the beta release as a 'draft' and upload artifacts to that.  Then when that is done, we switch the release from a 'draft' to a normal pre-release