### PR TITLE
Fix issues with volume/brightness getting 'stuck'

### DIFF
--- a/packages/351elec/package.mk
+++ b/packages/351elec/package.mk
@@ -52,7 +52,7 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/share/retroarch-overlays
   if [ "$DEVICE" == "RG351P" ]; then
     cp -r $PKG_DIR/overlay-p/* $INSTALL/usr/share/retroarch-overlays
-  elif [ "$DEVICE" == "RG351V" ]; then
+  elif [ "$DEVICE" == "RG351V" ] || [ "$DEVICE" == "RG351MP" ]; then
     cp -r $PKG_DIR/overlay-v/* $INSTALL/usr/share/retroarch-overlays
   fi
 

--- a/packages/351elec/sources/scripts/brightness
+++ b/packages/351elec/sources/scripts/brightness
@@ -5,9 +5,12 @@
 MIN=1
 MAX=100
 STEP=1
+if [[ -n "$2" ]]; then                               
+  STEP=$2                                               
+fi
 
 # Ensure set_ee_setting exists in all contexts
-if ! type set_ee_setting  >/dev/null
+if ! type set_ee_setting  &>/dev/null
 then
   source /etc/profile
 fi

--- a/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
+++ b/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
@@ -43,6 +43,10 @@ fi
 
 if [ "${1}" == "vol" ];then
 VOLSTEP=1
+if [ -n "${3}" ]; then
+  VOLSTEP="${3}"
+fi
+
 CURRENTVOL=$(get_ee_setting "audio.volume")
 MAXVOL=100
 MINVOL=0

--- a/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -19,14 +19,14 @@ set -o pipefail
 
 RG351_DEVICE='/dev/input/by-path/platform-rg351-keys-event'  # Device for volume key events
 
-RG351_CONTROLLER_DEVICE='/dev/input/event3' # Joystick events (for Fn key)
+RG351_CONTROLLER_DEVICE='/dev/input/event2' # Joystick events (for Fn key)
 
 VOL_EVENT='*(KEY_VOLUME*, value *' # This matches all volume events
 
 VOL_UP='*UP), value *'  # Differentiate 'up' volume event
 VOL_DOWN='*DOWN), value *' #Differentiate 'down' volume event
 
-V_FUNC_KEY_EVENT='*(BTN_TR2), value *' # Matches all RG351MP Fn key events
+V_FUNC_KEY_EVENT='*(BTN_TRIGGER_HAPPY4), value *' # Matches all RG351MP Fn key events
 
 # Matches if a button was pressed (1), released (0) or held down (2)
 PRESS='*value 1'
@@ -34,14 +34,10 @@ RELEASE='*value 0'
 REPEAT_PRESS="* value 2"
 
 # Volume repeat
-# volume repeat speed is faster (every 3rd repeat event) 
-#  as there are many stops (0-100 by increments of 1)
-VOLUME_REPEAT_MOD=3
+VOLUME_REPEAT_MOD=5
 
 # Brightness repeat
-# brightness repeat speed is faster (every 3rd repeat event) 
-#  as there are many stops (0-100 by increments of 1)
-BRIGHTNESS_REPEAT_MOD=3
+BRIGHTNESS_REPEAT_MOD=5
 
 # Variable to keep track of Fn being currently pressed
 FUNC_PRESSED=no
@@ -81,6 +77,7 @@ done
 
           # We don't care when you 'let go' ('release') the volume button
           if [[ "$line" == ${RELEASE} ]]; then
+             REPEAT_NUM=0
              continue
           fi
 
@@ -105,11 +102,17 @@ done
              continue
           fi
 
+          INCREMENT_AMOUNT=1
+          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
+             INCREMENT_AMOUNT=5
+          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
+             INCREMENT_AMOUNT=2
+          fi   
           # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
-            ${COMMAND} ${UP} > /dev/null
+            ${COMMAND} ${UP} ${INCREMENT_AMOUNT} > /dev/null
           elif [[ "${line}" == ${VOL_DOWN} ]]; then
-            ${COMMAND} ${DOWN} > /dev/null
+            ${COMMAND} ${DOWN} ${INCREMENT_AMOUNT} > /dev/null
           fi
         ;;
 

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
@@ -43,6 +43,9 @@ fi
 
 if [ "${1}" == "vol" ];then
 VOLSTEP=1
+if [ -n "${3}" ]; then
+  VOLSTEP="${3}"
+fi
 CURRENTVOL=$(get_ee_setting "audio.volume")
 MAXVOL=100
 MINVOL=0

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -81,6 +81,7 @@ done
 
           # We don't care when you 'let go' ('release') the volume button
           if [[ "$line" == ${RELEASE} ]]; then
+             REPEAT_NUM=0
              continue
           fi
 
@@ -105,11 +106,17 @@ done
              continue
           fi
 
+          INCREMENT_AMOUNT=1
+          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
+             INCREMENT_AMOUNT=5
+          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
+             INCREMENT_AMOUNT=2
+          fi
           # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
-            ${COMMAND} ${UP} > /dev/null
+            ${COMMAND} ${UP} ${INCREMENT_AMOUNT} > /dev/null
           elif [[ "${line}" == ${VOL_DOWN} ]]; then
-            ${COMMAND} ${DOWN} > /dev/null
+            ${COMMAND} ${DOWN} ${INCREMENT_AMOUNT} > /dev/null
           fi
         ;;
 


### PR DESCRIPTION
# Issue
In recent betas, there were changes to add fine grained control over volume/brightness to be able to adjust in increments of "1" instead of "5".  This is great for fine tuning, but results in an issue.
- To get volume/brightness increase fast enough, the 'repeat' speed is made faster.  The problem is in some scenarios the script to adjust volume/brightness is called so often the 'repeat' events from the controller cannot be processed realtime and get queued up.  This results in behavior where the 'repeat' continues after letting up the button, which is very confusing.


Additionally, the MP didn't support brightness increase at all due to the difference between the 'Fn' button on the V and 'R3' on the MP (technically the Fn key on the V **is** R3, but the difference in USB vs GPIO controllers means the mapping is still different).

# Fixes
- Decrease the 'repeat' rate of buttons so they don't overwhelm the system. However, to make going from 1-100 faster.  Increase the number of values 'skipped' over time.  So you start holding and increase is slow, then faster, then really fast.
 - If you press the button and don't hold, you can still adjust by increments of 1 for fine grained tuning.
 - To test volume speed, I'd suggest enabling `Sound Settings -> Show Overlay When Volume Changes`.  Then in ES you can see a volume bar to see how the speed adjusts as you hold down.
- Fix the button mapping on the MP.  This allows holding down 'R3' on the MP and the volume +/- key to adjust the brightness.

# Additional Change
- Fixed the overlays being missing on the MP.  This isn't really related, but given I've already opened way too many PR's today I didn't want to open another. :)