### PR TITLE
Bezel fixes: 1. Remove old defaults. 2. Fix old defaults on upgrade

### DIFF
--- a/packages/351elec/config/distribution/configs/distribution.conf
+++ b/packages/351elec/config/distribution/configs/distribution.conf
@@ -24,9 +24,6 @@ ee_videomode=480p60hz
 ## What to start at boot Emulationstation or Retroarch
 ee_boot=Emulationstation
 
-## Enable retroarch bezels
-global.bezel=0
-
 ## Enable splash screens
 ee_splash.enabled=0
 
@@ -209,13 +206,10 @@ fbn.rgascale=1
 fds.ratio=4/3
 fds.rgascale=1
 gamegear.integerscale=1
-gamegear.bezel=351ELEC-Gamegear
 gb.integerscale=1
-gb.bezel=351ELEC-Gameboy
 gba.ratio=3/2
 gbah.ratio=3/2
 gbc.integerscale=1
-gbc.bezel=351ELEC-GameboyColor
 gbch.integerscale=1
 gbh.integerscale=1
 genesis.ratio=4/3
@@ -273,7 +267,6 @@ pcfx.maxperf=1
 pcfx.ratio=4/3
 pcfx.rgascale=1
 pokemini.ratio=3/2
-pokemini.bezel=351ELEC-PokemonMini
 psp.maxperf=1
 pspminis.maxperf=1
 psx.ratio=4/3
@@ -297,7 +290,6 @@ snesmsu1.rgascale=1
 supergrafx.ratio=4/3
 supergrafx.rgascale=1
 supervision.integerscale=1
-supervision.bezel=351ELEC-Supervision
 tg16.ratio=4/3
 tg16.rgascale=1
 tg16cd.ratio=4/3

--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -6,6 +6,17 @@
 CONF="/storage/.config/distribution/configs/distribution.conf"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
 
+## 2021-10-04
+## Remove old bezel configs
+### Done in a single sed to keep performance fast
+sed -i '/global.bezel=0/d;
+        /gb.bezel=351ELEC-Gameboy/d;
+        /gamegear.bezel=351ELEC-Gamegear/d;
+        /gbc.bezel=351ELEC-GameboyColor/d;
+        /pokemini.bezel=351ELEC-PokemonMini/d;
+        /supervision.bezel=351ELEC-Supervision/d;
+        ' /storage/.config/distribution/configs/distribution.conf
+
 ## 2021-09-30:
 ## Remove any configurd ES joypads on upgrade
 rm -f /storage/joypads/*.cfg


### PR DESCRIPTION
# Summary
This fixes @acridAxid's issues where bezels wouldn't show until by default until going into the advanced system config.

# Technical details
In a previous implementation of bezels, the bezels were system specific (one bezel for gb, one for gbc, etc.  Ex: `gb.bezel=351ELEC-Gameboy`).  The defaults weren't removed in distribution.conf, so on a fresh flash appeared that you had set a non-existent bezel in advanced system configuration.  The is the root of the issue.

I didn't see this because even on a fresh flash I would go into the adavanced config to check how it looked before launching.  The code in the ES configuration is smart enough to see that a value that doesn't exist was set and 'fix it' (that's why when navigating to the correct config it would 'just work'). 

I've fixed so that 1. The defaults are now correct.  2. Upgrade will remove the old bezel values.

# Testing
- I installed from an .img and spot checked that GB/GBC bezels worked by default and game specific bezels also worked by default.
- I upgraded from the previous beta and checked the same.
