### PR TITLE
Run postupdate after restore from backup

### DIFF
--- a/packages/351elec/sources/scripts/emuelec-utils
+++ b/packages/351elec/sources/scripts/emuelec-utils
@@ -100,6 +100,7 @@ function ee_backup() {
         "restore")
                 systemctl stop emustation
                 unzip -o ${BACKUPFILE} -d /
+                /usr/bin/postupdate.sh
                 sleep 3
                 systemctl start emustation
         ;;


### PR DESCRIPTION
# Summary
- "Restore backup" restores configuration files that may have been upgraded in earlier releases (depending on the age of the backup).  
  - This change just runs the 'postupdate' after restoring a backup.  This makes it so the config files should continue to work normally w/o updating the software as they will be 'upgraded' as though the software was just updated.
- This also makes it possible that if there are upgrades which affect the roms on a second SD card and it's not in the device during upgrade, there is a workaround: `backup / restore`.  
  - We could also expose a way to directly run this postupdate script, but I think it's best to wait until we have a concrete reason before adding new menu items.