### PR TITLE
Add bezel support for potator (supervision)

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_features.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_features.cfg
@@ -61,7 +61,7 @@
       <core name="prosystem" features="netplay, rewind, autosave, cheevos" />
       <core name="puae" features="netplay, rewind, autosave" />
       <core name="px68k" features="netplay, rewind, autosave" />
-      <core name="potator" features="cheevos" />
+      <core name="potator" features="decoration, cheevos" />
       <core name="quasi88" features="netplay, rewind, autosave" />
       <core name="quicknes" features="netplay, rewind, autosave, cheevos" />
       <core name="race" features="decoration, netplay, rewind, autosave, cheevos" />


### PR DESCRIPTION
# Summary
Supervision (potator emulator) has default bezels, but does not have 'decorations' enabled in ES so it is not possible to configure (as per @konsumschaf).

Full disclosure - did not test - but change seems simple enough.