### PR TITLE
Enhance Upgrade Logic - Edge Case

### DIFF
--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -6,6 +6,14 @@
 CONF="/storage/.config/distribution/configs/distribution.conf"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
 
+## 2021-10-07
+## Copy es_input.cfg over on every update
+## This prevents a user with an old es_input from getting the 'input config scree'
+### I don't believe there is a use case where a user needed to customize es_input.xml intentionally
+if [ -f /usr/config/emulationstation/es_input.cfg ]; then
+	cp /usr/config/emulationstation/es_input.cfg /storage/.emulationstation/
+fi
+
 ## 2021-10-04
 ## Remove old bezel configs
 ### Done in a single sed to keep performance fast


### PR DESCRIPTION
# Post Update Fixes
- Always replace es_input.cfg.  As we have remove ES ability to configure - this should be fine.  If you restore from an old backup, it is currently possible to get the 'input' screen.  Configure a controller, but have no way to undo.

NOTE: I was thinking about removing the ~2000 `input_player*` lines from retroarch.cfg, but I'm not sure if there are update cases where people would have set controls we don't want to overwrite (turbo?).  So - I did not put it in.