### PR TITLE
Build dev branch and dev branch PRs

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -11,6 +11,7 @@ on:
       - '.dockerignore'
     branches:
       - main
+      - dev
 # Ensure that if there are multiple builds for main only 1 is queued during a build
 # Example: 1st commit in main starts a build then 2-9 commits come in during the first build.
 #          'concurrency' makes it so that only commit 9 is enqueued to build rather builds 2-9 all runing a build.

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -10,6 +10,7 @@ on:
       - '.dockerignore'
     branches:
       - main
+      - dev
     types: [opened, synchronize, ready_for_review, labeled]
 
 # Ensure that if there are multiple builds for a PR only 1 is queued


### PR DESCRIPTION
# Summary
This contains changes to build the dev branch and PR's to the dev branch in addition to `main`.

Technically, it appears this could work if only committed to `dev` (from testing in pkegg).  However, based on documentation, the default branch (`main`) is supposed to be driving Github Action workflows.  I think it's best to commit to main **and** merge to dev (or the other way around if you prefer) and keep the .github/workflow/* files in sync between dev and main.