### PR TITLE
Build uae4arm as 64-bit

### DIFF
--- a/packages/351elec/sources/scripts/runemu.sh
+++ b/packages/351elec/sources/scripts/runemu.sh
@@ -339,7 +339,7 @@ else
 
 	### Check if we need retroarch 32 bits or 64 bits
 	RABIN="retroarch"
-	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]] || [[ "${CORE}" =~ "uae4arm" ]]
+	if [[ "${CORE}" =~ "pcsx_rearmed" ]] || [[ "${CORE}" =~ "parallel_n64" ]]
 	then
 		export LD_LIBRARY_PATH="/usr/lib32"
 		RABIN="retroarch32"

--- a/packages/games/libretro/uae4arm/package.mk
+++ b/packages/games/libretro/uae4arm/package.mk
@@ -19,14 +19,14 @@
 ################################################################################
 
 PKG_NAME="uae4arm"
-PKG_VERSION="1aa6b6b3a1c08f70099da2d5d8a8dea816aa1ca8"
-PKG_SHA256="fe9971107330b7d5d33ba19d5a868cd27209edc1aacff003db768afaa0da5263"
+PKG_VERSION="4d2e723667a84fcdca73102eb91a83b3c60edba3"
+PKG_SHA256="9293d7e690079ff1a55c3df993a74274fbfcbe05196ee70c273ba02fa38df268"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/libretro/uae4arm-libretro"
+PKG_SITE="https://github.com/Chips-fr/uae4arm-rpi"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain flac mpg123"
 PKG_PRIORITY="optional"
 PKG_SECTION="libretro"
 PKG_SHORTDESC="Port of uae4arm for libretro (rpi/android)"
@@ -35,23 +35,12 @@ PKG_LONGDESC="Port of uae4arm for libretro (rpi/android) "
 PKG_IS_ADDON="no"
 PKG_TOOLCHAIN="make"
 PKG_AUTORECONF="no"
-PKG_BUILD_FLAGS="-lto"
 
 make_target() {
-  if [ "${ARCH}" != "aarch64" ]; then
-    CFLAGS="$CFLAGS -DARM -marm"
-    if [[ "$TARGET_FPU" =~ "neon" ]]; then
-      CFLAGS="-D__NEON_OPT"
-    fi
-    make HAVE_NEON=1 USE_PICASSO96=1
-  fi
+  make -f Makefile.libretro platform=unix_aarch64 "CPU_FLAGS=-mcpu=cortex-a35+crypto+crc"
 }
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
-  if [ "${ARCH}" != "aarch64" ]; then
-    cp uae4arm_libretro.so $INSTALL/usr/lib/libretro/
-  else
-    cp -vP $PKG_BUILD/../../build.${DISTRO}-${DEVICE}.arm/uae4arm-*/.install_pkg/usr/lib/libretro/uae4arm_libretro.so $INSTALL/usr/lib/libretro/
-  fi
+  cp uae4arm_libretro.so $INSTALL/usr/lib/libretro/
 }

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -35,7 +35,7 @@ then
 fi
 
 sleep 0.2
-if [[ "$1" =~ "pcsx_rearmed" ]] || [[ "$1" =~ "parallel_n64" ]] || [[ "$1" =~ "uae4arm" ]]
+if [[ "$1" =~ "pcsx_rearmed" ]] || [[ "$1" =~ "parallel_n64" ]]
 then
     echo 'using 32bit'
   	export LD_LIBRARY_PATH="/usr/lib32"

--- a/scripts/build_distro
+++ b/scripts/build_distro
@@ -34,7 +34,7 @@ elif [ "${ARCH}" == "arm" ]
 then
   # Only build the 32bit packages that we need rather than the whole image
   # to speed up the build process and save disk space.
-  for package in gcc retroarch retrorun pcsx_rearmed parallel-n64 parallel-n64_gln64 uae4arm SDL2 SDL2-14 SDL2_image SDL2_mixer SDL2_net SDL2_ttf SDL2_gfx
+  for package in gcc retroarch retrorun pcsx_rearmed parallel-n64 parallel-n64_gln64 SDL2 SDL2-14 SDL2_image SDL2_mixer SDL2_net SDL2_ttf SDL2_gfx
   do
     scripts/build ${package}
     if [ ! $? == 0 ]


### PR DESCRIPTION
This builds the core from the original repository, instead of libretro's fork of it. This has a few advantages due to it being more up to date:
- We can build it as 64 bit. Yay! One less 32-bit component to deal with.
- A few emulation fixes (no more lines in the middle of the screen in Roots 2.0)
- CD32 (and CDTV) support (es_systems.cfg already had uae4arm as a core for CD32, so we don't need to do anything here; interesting that it apparently didn't work before and I thought I did go through and check what didn't work with CD32 a while back, so maybe I did that wrong, but it works now so it's okay)
- Slightly faster by a few FPS for AGA software, could be within the margin of error and not really caused by the core being improved, but either way there are no performance regressions or anything