### PR TITLE
Add missing cheevos support

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_features.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_features.cfg
@@ -71,7 +71,7 @@
       <core name="gme" features="netplay, rewind, autosave" />
       <core name="gpsp" features="netplay, rewind, autosave, cheevos" />
       <core name="gw" features="netplay, rewind, autosave" />
-      <core name="handy" features="netplay, rewind, autosave" />
+      <core name="handy" features="netplay, rewind, autosave, cheevos" />
       <core name="hatari" features="netplay, rewind, autosave" />
       <core name="mame2003_plus" features="netplay, rewind, autosave" />
       <core name="mame2010" features="netplay, rewind, autosave" />
@@ -84,7 +84,7 @@
       <core name="beetle_supergrafx" features="netplay, rewind, autosave, cheevos" />
       <core name="beetle_vb" features="netplay, rewind, autosave, cheevos" />
       <core name="beetle_wswan" features="decoration, netplay, rewind, autosave, cheevos" />
-      <core name="mesen-s" features="netplay, rewind, autosave" />
+      <core name="mesen-s" features="netplay, rewind, autosave, cheevos" />
       <core name="mgba" features="decoration, netplay, rewind, autosave, cheevos" />
       <core name="mrboom" features="netplay, rewind, autosave" />
       <core name="mupen64plus_next" features="netplay, rewind, autosave, cheevos" />
@@ -99,14 +99,14 @@
       <core name="parallel_n64" features="netplay, rewind, autosave, cheevos" />
       <core name="pcsx_rearmed" features="netplay, rewind, autosave, cheevos" />
       <core name="picodrive" features="decoration, netplay, rewind, autosave, cheevos" />
-      <core name="pokemini" features="decoration, netplay, rewind, autosave" />
+      <core name="pokemini" features="decoration, netplay, rewind, autosave, cheevos" />
       <core name="ppsspp" features="netplay, rewind, autosave, cheevos" />
       <core name="prboom" features="netplay, rewind, autosave" />
       <core name="prosystem" features="netplay, rewind, autosave, cheevos" />
       <core name="puae" features="netplay, rewind, autosave" />
       <core name="px68k" features="netplay, rewind, autosave" />
       <core name="potator" features="decoration, cheevos" />
-      <core name="quasi88" features="netplay, rewind, autosave" />
+      <core name="quasi88" features="netplay, rewind, autosave, cheevos" />
       <core name="quicknes" features="netplay, rewind, autosave, cheevos" />
       <core name="race" features="decoration, netplay, rewind, autosave, cheevos" />
       <core name="reminiscence" features="netplay, rewind, autosave" />


### PR DESCRIPTION
Checked against https://docs.libretro.com/guides/retroachievements/
Add missing cheevos support for:
* handy
* mesen-s
* pokemini
* quasi88