### PR TITLE
Update timeout to 60

### DIFF
--- a/packages/351elec/sources/scripts/get-release.py
+++ b/packages/351elec/sources/scripts/get-release.py
@@ -19,7 +19,7 @@ import re
 logger = logging.getLogger(__name__)
 
 # Ensure downloads timeoout w/no data as normal timeout is infinite
-socket.setdefaulttimeout(30)
+socket.setdefaulttimeout(60)
 
 
 class CONSOLE:


### PR DESCRIPTION
# Summary
It seems like some of the github downloads have a longer delay on starting recently.  dhwz made a change to increase the timeout from 15 to 30.  This makes things better, but I still see some cases where it fails.  Bumping to 60 seems to consistently fix for me.

## Testing info
Figured this was a good time to document how to test this so others can test too

FYI - you can test the download script (`packages/351elec/sources/scripts/get-release.py`) from linux (or on the device).  There are options to adjust where the 'console' is printed (`--console`) to and the download goes (`--update-dir`).  It is also an option to turn on `--log-level DEBUG` to get more logging (doesn't really help here as it's a timeout, but can be interesting).  See: `python3 get-release.py --help`

## Specific tests
I see this fail sometimes with `30` still - but works reliably at 60.  Technically this is downloading the old crazy hedgehog 'release' 
```
cd packages/351elec/sources/scripts/
python3 get-release.py --update-dir /tmp/update  --console /dev/stderr --band release
```

I'm not sure if it's consistent for all, but the beta seems to download fast for me.  You can check it like this - this consistently works for me with 30:
`python3 get-release.py --update-dir /tmp/update  --console /dev/stderr --band beta  --repo 351ELEC-beta`

