### PR TITLE
Add meson

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update  \
       libvlc-dev libvlccore-dev vlc-bin texinfo premake4 golang libssl-dev curl patchelf \
       xmlstarlet patchutils gawk gperf xfonts-utils default-jre python xsltproc libjson-perl \
       lzop libncurses5-dev device-tree-compiler u-boot-tools rsync p7zip unrar libparse-yapp-perl \
-      zip binutils-aarch64-linux-gnu dos2unix p7zip-full libvpx-dev bsdmainutils bc \
+      zip binutils-aarch64-linux-gnu dos2unix p7zip-full libvpx-dev bsdmainutils bc meson \
       && apt-get autoremove --purge -y \
       && apt-get clean -y \
       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I guess none of our components needed meson before, but it's supported by build infrastructure so we should add.  Also - seems to fix this build failure: https://github.com/351ELEC/351ELEC/runs/4204575343?check_suite_focus=true