### PR TITLE
Add support for .CAR files to atari800

### DIFF
--- a/packages/ui/351elec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_systems.cfg
@@ -139,7 +139,7 @@
     <release>1982</release>
     <hardware>console</hardware>
     <path>/storage/roms/atari5200</path>
-    <extension>.rom .ROM .xfd .XFD .atr .ATR .atx .ATX .cdm .CDM .cas .CAS .bin .BIN .a52 .A52 .xex .XEX .zip .ZIP .7z .7Z</extension>
+    <extension>.rom .ROM .xfd .XFD .atr .ATR .atx .ATX .cdm .CDM .cas .CAS .car .CAR .bin .BIN .a52 .A52 .xex .XEX .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>atari5200</platform>
     <theme>atari5200</theme>
@@ -177,7 +177,7 @@
     <release>1979</release>
     <hardware>console</hardware>
     <path>/storage/roms/atari800</path>
-    <extension>.rom .ROM .xfd .XFD .atr .ATR .atx .ATX .cdm .CDM .cas .CAS .bin .BIN .a52 .A52 .xex .XEX .zip .ZIP .7z .7Z</extension>
+    <extension>.rom .ROM .xfd .XFD .atr .ATR .atx .ATX .cdm .CDM .cas .CAS .car .CAR .bin .BIN .a52 .A52 .xex .XEX .zip .ZIP .7z .7Z</extension>
     <command>/usr/bin/runemu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
     <platform>atari800</platform>
     <theme>atari800</theme>


### PR DESCRIPTION
.CAR is a common format for cartridge images.