### PR TITLE
Switch beta to prerelease

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,7 +1,7 @@
 name: build-main
 on:
   repository_dispatch:
-    types: [release-beta, release-draft]
+    types: [release-beta, release-prerelease, release-draft]
   workflow_dispatch:
   push:
     paths-ignore:
@@ -96,20 +96,57 @@ jobs:
           path: |
             release/aarch64/RG351MP/
       - name: Create pre-release as draft at first to hide during uploads
+        if: github.event.action == 'release-prerelease'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          body: |
+            # Release Notes (Prerelease)
+            This is a prerelease based on the commit: ${{ github.event.repository.full_name }}@${{github.sha}}.
+    
+            Prereleases and provided for the community to test fixes and explore new functionality.  Please DO NOT open issues on this build and instead post in the `#pre-release-feedback` section of discord.
+            
+            See the [wiki](https://351elec.de/Contributing-to-351ELEC) for more info.
+            
+            ### Changes (since last prerelease version):
+            ${{ github.event.client_payload.release_notes }}
+            
+            ### Upgrade Instructions
+            You can update to this release using the `prerelease` channel on your device. This is the recommended way to use prerelease versions.
+            
+             **IMPORTANT NOTE**: There are **three different images** below, one for the **RG351P/M**, **RG351V** and **RG351MP**! 
+
+            **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.tar)**
+
+          artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*, release/aarch64/RG351MP/*"
+          prerelease: true
+          draft: true
+          token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+          repo: 351ELEC-prerelease
+      - name: Switch draft to start showing release 
+        if: github.event.action == 'release-prerelease'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          allowUpdates: true
+          draft: false
+          prerelease: true
+          token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+          repo: 351ELEC-prerelease
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+
+      #This can be removed after no more 'bridge' betas are needed
+      - name: Create pre-release as draft at first to hide during uploads
         if: github.event.action == 'release-beta'
         uses: ncipollo/release-action@v1
         with:
           tag: "${{ steps.version.outputs.version }}"
           body: |
             # Release Notes (Beta)
-            This is a pre-release based on the commit: ${{ github.event.repository.full_name }}@${{github.sha}}.
-    
-            Beta releases are unstable and provided for the community to test fixes and explore new functionality.  Please DO NOT open issues on this build and instead post in the `#beta-feedback` section of discord.
-            
-            See the [wiki](https://351elec.de/Contributing-to-351ELEC) for more info.
-            
-            ### Changes (since last beta version):
-            ${{ github.event.client_payload.release_notes }}
+            This beta is provided as a OTA bridge to the new pre-releases
             
             ### Upgrade Instructions
             You can update to this release using the `beta` channel on your device. This is the recommended way to use beta versions.
@@ -117,14 +154,14 @@ jobs:
              **IMPORTANT NOTE**: There are **three different images** below, one for the **RG351P/M**, **RG351V** and **RG351MP**! 
 
             **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
-            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.img.gz)**
-            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.tar)**
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.tar)**
 
           artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*, release/aarch64/RG351MP/*"
           prerelease: true
           draft: true
           token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
-          repo: 351ELEC-beta
+          repo: 351ELEC-prerelease
       - name: Switch draft to start showing release 
         if: github.event.action == 'release-beta'
         uses: ncipollo/release-action@v1
@@ -134,7 +171,7 @@ jobs:
           draft: false
           prerelease: true
           token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
-          repo: 351ELEC-beta
+          repo: 351ELEC-prerelease
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
       - name: Create draft release

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -4,8 +4,8 @@
 #  It can also be run manually.
 name: release-beta
 on:
-  schedule:
-    - cron:  '0 20 * * *'
+  #schedule:
+  #  - cron:  '0 20 * * *'
   workflow_dispatch:  # allows manual runs
     
 jobs:

--- a/.github/workflows/release-prerelease.yaml
+++ b/.github/workflows/release-prerelease.yaml
@@ -1,15 +1,15 @@
 
-# The purpose of this build is to allow a 'beta' release be created.
-#  Typically, it will be created every day if there are new commits since the last tag (beta)
+# The purpose of this build is to allow a 'prerelease' release be created.
+#  Typically, it will be created every day if there are new commits since the last tag (prerelease)
 #  It can also be run manually.
-name: release-beta
+name: release-prerelease
 on:
   schedule:
     - cron:  '0 20 * * *'
   workflow_dispatch:  # allows manual runs
     
 jobs:
-  launch-beta-release-if-needed:
+  launch-prerelease-release-if-needed:
       runs-on: ubuntu-20.04
       steps:
         #- uses: hmarr/debug-action@v2
@@ -30,19 +30,19 @@ jobs:
           id: changes
           run: |
           
-              #Figure out last beta date by converting the latest 351ELEC-beta tag into a date and 
+              #Figure out last prerelease date by converting the latest 351ELEC-prerelease tag into a date and 
               # looking for commits in 351ELEC newer than that date
-              git clone https://github.com/${{ steps.full_name.outputs.full_name }}-prerelease beta
-              pushd beta
-              last_tag=$(git tag -l | grep "beta-" | tail -1)
-              last_beta_formatted=$(echo ${last_tag} | sed 's/beta-//g ; s/_/ /g')
-              last_beta_date=$(date -d"${last_beta_formatted}")
-              echo "last beta date: ${last_beta_date}"
+              git clone https://github.com/${{ steps.full_name.outputs.full_name }}-prerelease prerelease
+              pushd prerelease
+              last_tag=$(git tag -l | tail -1)
+              last_prerelease_formatted=$(echo ${last_tag} | sed 's/prerelease-//g ; s/_/ /g')
+              last_prerelease_date=$(date -d"${last_prerelease_formatted}")
+              echo "last prerelease date: ${last_prerelease_date}"
               popd
               
-              echo ::set-output name=changes::$(git log --after="${last_beta_date}" --oneline | wc -l)
+              echo ::set-output name=changes::$(git log --after="${last_prerelease_date}" --oneline | wc -l)
               
-              release_notes="$(git log --after=\\"${last_beta_date}\\" --oneline | sed 's|^|${{ steps.full_name.outputs.full_name }}@|g')"
+              release_notes="$(git log --after=\\"${last_prerelease_date}\\" --oneline | sed 's|^|${{ steps.full_name.outputs.full_name }}@|g')"
               
               # The below lines translate linebreaks so they can be set into the 'release_notes' variable
               release_notes="${release_notes//'%'/'%25'}"
@@ -60,10 +60,10 @@ jobs:
           with:
             token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
             repository: ${{ steps.full_name.outputs.full_name }}
-            event-type: release-beta
+            event-type: release-prerelease
             client-payload: |
                {
-                 "release_tag" : "beta-${{steps.date.outputs.date}}",
+                 "release_tag" : "prerelease-${{steps.date.outputs.date}}",
                  "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
                }
             

--- a/Makefile
+++ b/Makefile
@@ -131,5 +131,5 @@ docker-image-push:
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:
-	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --env-file .env --rm --user $(UID):$(GID) $(DEVELOPER_SETTINGS) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
+	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --init --env-file .env --rm --user $(UID):$(GID) $(DEVELOPER_SETTINGS) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
 

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -16,8 +16,8 @@ fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
-  if [ "$BAND" == "beta" ]; then
-    REPO=351ELEC-beta
+  if [ "$BAND" == "prerelease" ] || [ "$BAND" == "beta" ]; then
+    REPO=351ELEC-prerelease
   else
     REPO=351ELEC
   fi

--- a/packages/351elec/sources/scripts/updatecheck
+++ b/packages/351elec/sources/scripts/updatecheck
@@ -12,8 +12,8 @@ fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
-  if [ "$BAND" == "beta" ]; then
-    REPO=351ELEC-beta
+  if [ "$BAND" == "prerelease" ] || [ "$BAND" == "beta" ]; then
+    REPO=351ELEC-prerelease
   else
     REPO=351ELEC
   fi

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="ffe39fe1326a88cdd86428dce88bd67697f85ffc"
+PKG_VERSION="cda2c543676c4fb023ea6fc4022aaa0033b07cf8"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
# Summary
We want to switch `beta` to `prerelease` to better match the content of what's actually in the releases.  Renaming the versions from `beta-` to `prerelease-` is actually a problem for the Pineapple Forrest release as it will ignore versions called `prerelease-*` when looking for updates.  

To work around this, we will issue a beta with the new code to update to pre-releases.  From that 'final' beta, users will be able to update to prereleases.  Once a new 'release' is issued, that won't be a problem.

This is still in draft because of TBD below and I still need to test on device.

# Issues to Consider
- Renaming 351ELEC-beta to 351ELEC-prerelease
   -  Edit: This is OK as GitHub is smart enough to redirect API/download requests from the old repo to the new one.
- Renaming the beta releases versions to start with: `prerelease-` instead of `beta-`.  This unfortunately means the released Pineapple Forest release cannot jump straight to these versions as mentioned above.  However, it is important for clarity to users (having a 'prerelease' channel that shows 'beta' versions installed is confusing.
- The code in Pineapple Forrest which parses versions has a minor bug which means that if pre-releases and beta releases share the same repository (351ELEC-prerelease) betas will lose the ability to find the `final` beta after 100 prereleases are issued.  The issue is the code does  not properly request the next 'page' of releases from the GitHub API.
  -  Edit: This really just means we need to get our next 'release' out before issuing 100 pre-releases or if it's really a problem, just issue another 'bridge' beta.

# Minor Fixes
- Also made a minor fix to launch docker builds with `--init`, this just makes `ctrl-c` work more reliably when killing docker based builds.
- Fixed API pagination issue so in some sort of weird case, the device can query for more than 100 releases.
- Made the `get-release.py` script respect the `GITHUB_TOKEN` environment variable
  - This is really only for testing/dev, but `get-release.py` makes more than 60 API requests per hour (because you're testing API pagination for example), you can set that GITHUB_TOKEN to GitHub Personal Access Token and that bumps you up to 5000 API requests per hour.  No normal user should ever need this when checking for updates.