### PR TITLE
Fix netplay client

### DIFF
--- a/packages/351elec/sources/scripts/runemu.sh
+++ b/packages/351elec/sources/scripts/runemu.sh
@@ -389,10 +389,7 @@ else
 	if [[ ${NETPLAY} != "No" ]]; then
 		NETPLAY_NICK=$(get_ee_setting netplay.nickname)
 		[[ -z "$NETPLAY_NICK" ]] && NETPLAY_NICK="351ELEC"
-		NETPLAY="$(echo ${NETPLAY} | sed "s|--nick|--nick \"${NETPLAY_NICK}\"|")"
-
-		RUNTHIS=$(echo ${RUNTHIS} | sed "s|--config|${NETPLAY} --config|")
-
+		
 		if [[ "${NETPLAY}" == *"connect"* ]]; then
 			NETPLAY_PORT="${arguments##*--port }"  # read from -netplayport  onwards
 			NETPLAY_PORT="${NETPLAY_PORT%% *}"  # until a space is found
@@ -400,6 +397,9 @@ else
 			NETPLAY_IP="${NETPLAY_IP%% *}"  # until a space is found
 			set_ee_setting "netplay.client.ip" "${NETPLAY_IP}"
 			set_ee_setting "netplay.client.port" "${NETPLAY_PORT}"
+			RUNTHIS=$(echo ${RUNTHIS} | sed "s|--config|--connect ${NETPLAY_IP}\|${NETPLAY_PORT} --nick ${NETPLAY_NICK} --config|")
+		else
+			RUNTHIS=$(echo ${RUNTHIS} | sed "s|--config|${NETPLAY} --nick ${NETPLAY_NICK} --config|")
 		fi
 
 	fi


### PR DESCRIPTION
And also submit the pull request properly this time, sorry.

See also PR 13250 in RetroArch, they apparently changed it in the most recent build so --connect and --port cannot be used together and everyone was supposed to use host|port and nobody noticed until now, hence breaking things for everyone else.

Note: I haven't actually tested this change as I have no friends to do netplay with etc (and have been rewriting runemu.py anyway), but I did test the sed commands in the lines I individually added to make sure I understand how sed works, hopefully this will not break