### PR TITLE
Switch Beta to Prereleases - Dev

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,7 +1,7 @@
 name: build-main
 on:
   repository_dispatch:
-    types: [release-beta, release-draft]
+    types: [release-beta, release-prerelease, release-draft]
   workflow_dispatch:
   push:
     paths-ignore:
@@ -96,20 +96,57 @@ jobs:
           path: |
             release/aarch64/RG351MP/
       - name: Create pre-release as draft at first to hide during uploads
+        if: github.event.action == 'release-prerelease'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          body: |
+            # Release Notes (Prerelease)
+            This is a prerelease based on the commit: ${{ github.event.repository.full_name }}@${{github.sha}}.
+    
+            Prereleases and provided for the community to test fixes and explore new functionality.  Please DO NOT open issues on this build and instead post in the `#pre-release-feedback` section of discord.
+            
+            See the [wiki](https://351elec.de/Contributing-to-351ELEC) for more info.
+            
+            ### Changes (since last prerelease version):
+            ${{ github.event.client_payload.release_notes }}
+            
+            ### Upgrade Instructions
+            You can update to this release using the `prerelease` channel on your device. This is the recommended way to use prerelease versions.
+            
+             **IMPORTANT NOTE**: There are **three different images** below, one for the **RG351P/M**, **RG351V** and **RG351MP**! 
+
+            **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.tar)**
+
+          artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*, release/aarch64/RG351MP/*"
+          prerelease: true
+          draft: true
+          token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+          repo: 351ELEC-prerelease
+      - name: Switch draft to start showing release 
+        if: github.event.action == 'release-prerelease'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          allowUpdates: true
+          draft: false
+          prerelease: true
+          token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+          repo: 351ELEC-prerelease
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+
+      #This can be removed after no more 'bridge' betas are needed
+      - name: Create pre-release as draft at first to hide during uploads
         if: github.event.action == 'release-beta'
         uses: ncipollo/release-action@v1
         with:
           tag: "${{ steps.version.outputs.version }}"
           body: |
             # Release Notes (Beta)
-            This is a pre-release based on the commit: ${{ github.event.repository.full_name }}@${{github.sha}}.
-    
-            Beta releases are unstable and provided for the community to test fixes and explore new functionality.  Please DO NOT open issues on this build and instead post in the `#beta-feedback` section of discord.
-            
-            See the [wiki](https://351elec.de/Contributing-to-351ELEC) for more info.
-            
-            ### Changes (since last beta version):
-            ${{ github.event.client_payload.release_notes }}
+            This beta is provided as a OTA bridge to the new pre-releases
             
             ### Upgrade Instructions
             You can update to this release using the `beta` channel on your device. This is the recommended way to use beta versions.
@@ -117,14 +154,14 @@ jobs:
              **IMPORTANT NOTE**: There are **three different images** below, one for the **RG351P/M**, **RG351V** and **RG351MP**! 
 
             **If you download the incorrect image for your device, it will not boot!**  If you are unsure, use the the following links:
-            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.img.gz)**
-            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-beta/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.tar)**
+            **New Installations** (`.img.gz`):  **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.img.gz)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.img.gz)**
+            **Upgrades** (place in `/storage/roms/update`): **[RG351P/M](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351P.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351V](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351V.aarch64-${{ steps.version.outputs.version }}.tar)** |  **[RG351MP](https://github.com/${{ github.event.repository.owner.login }}/351ELEC-prerelease/releases/download/${{ steps.version.outputs.version }}/351ELEC-RG351MP.aarch64-${{ steps.version.outputs.version }}.tar)**
 
           artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*, release/aarch64/RG351MP/*"
           prerelease: true
           draft: true
           token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
-          repo: 351ELEC-beta
+          repo: 351ELEC-prerelease
       - name: Switch draft to start showing release 
         if: github.event.action == 'release-beta'
         uses: ncipollo/release-action@v1
@@ -134,7 +171,7 @@ jobs:
           draft: false
           prerelease: true
           token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
-          repo: 351ELEC-beta
+          repo: 351ELEC-prerelease
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
       - name: Create draft release

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -25,10 +25,19 @@ jobs:
     steps:
       - uses: hmarr/debug-action@v2
         name: debug
+      - name: get current branch as it may not be 'default branch;
+        id: branch
+        run: |
+            branch_arg="${{ github.event.client_payload.branch }}"
+            if [[ -z "$branch_arg" ]]; then
+              branch_arg="$GITHUB_REF_NAME"
+            fi
+            echo "::set-output name=branch::$branch_arg"
       - uses: actions/checkout@v2
         name: checkout
         with:
           clean: false
+          ref: "${{ steps.branch.outputs.branch }}"
       - name: Get date for artifacts
         id: date
         run: echo "::set-output name=date::$(date +'%Y%m%d_%H%M')"

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -4,8 +4,8 @@
 #  It can also be run manually.
 name: release-beta
 on:
-  schedule:
-    - cron:  '0 20 * * *'
+  #schedule:
+  #  - cron:  '0 20 * * *'
   workflow_dispatch:  # allows manual runs
     
 jobs:

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -7,7 +7,9 @@ on:
   #schedule:
   #  - cron:  '0 20 * * *'
   workflow_dispatch:  # allows manual runs
-    
+env:
+  BRANCH: main
+
 jobs:
   launch-beta-release-if-needed:
       runs-on: ubuntu-20.04
@@ -19,7 +21,8 @@ jobs:
           with:
             clean: false
             fetch-depth: 0
-            
+            ref: "${{env.BRANCH}}"
+
         # We get the full name from git here as in the case of 'cron', it is not available on the event
         - name: repository full name
           id: full_name
@@ -63,6 +66,7 @@ jobs:
             event-type: release-beta
             client-payload: |
                {
+                 "branch" : "${{ env.BRANCH }}",
                  "release_tag" : "beta-${{steps.date.outputs.date}}",
                  "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
                }

--- a/.github/workflows/release-prerelease.yaml
+++ b/.github/workflows/release-prerelease.yaml
@@ -6,8 +6,11 @@ name: release-prerelease
 on:
   schedule:
     - cron:  '0 20 * * *'
+      
   workflow_dispatch:  # allows manual runs
-    
+env:
+  BRANCH: main
+
 jobs:
   launch-prerelease-release-if-needed:
       runs-on: ubuntu-20.04
@@ -19,6 +22,7 @@ jobs:
           with:
             clean: false
             fetch-depth: 0
+            ref: "${{env.BRANCH}}"
             
         # We get the full name from git here as in the case of 'cron', it is not available on the event
         - name: repository full name
@@ -63,6 +67,7 @@ jobs:
             event-type: release-prerelease
             client-payload: |
                {
+                 "branch" : "${{ env.BRANCH }}",
                  "release_tag" : "prerelease-${{steps.date.outputs.date}}",
                  "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
                }

--- a/.github/workflows/release-prerelease.yaml
+++ b/.github/workflows/release-prerelease.yaml
@@ -1,15 +1,15 @@
 
-# The purpose of this build is to allow a 'beta' release be created.
-#  Typically, it will be created every day if there are new commits since the last tag (beta)
+# The purpose of this build is to allow a 'prerelease' release be created.
+#  Typically, it will be created every day if there are new commits since the last tag (prerelease)
 #  It can also be run manually.
-name: release-beta
+name: release-prerelease
 on:
   schedule:
     - cron:  '0 20 * * *'
   workflow_dispatch:  # allows manual runs
     
 jobs:
-  launch-beta-release-if-needed:
+  launch-prerelease-release-if-needed:
       runs-on: ubuntu-20.04
       steps:
         #- uses: hmarr/debug-action@v2
@@ -30,19 +30,19 @@ jobs:
           id: changes
           run: |
           
-              #Figure out last beta date by converting the latest 351ELEC-beta tag into a date and 
+              #Figure out last prerelease date by converting the latest 351ELEC-prerelease tag into a date and 
               # looking for commits in 351ELEC newer than that date
-              git clone https://github.com/${{ steps.full_name.outputs.full_name }}-prerelease beta
-              pushd beta
-              last_tag=$(git tag -l | grep "beta-" | tail -1)
-              last_beta_formatted=$(echo ${last_tag} | sed 's/beta-//g ; s/_/ /g')
-              last_beta_date=$(date -d"${last_beta_formatted}")
-              echo "last beta date: ${last_beta_date}"
+              git clone https://github.com/${{ steps.full_name.outputs.full_name }}-prerelease prerelease
+              pushd prerelease
+              last_tag=$(git tag -l | tail -1)
+              last_prerelease_formatted=$(echo ${last_tag} | sed 's/prerelease-//g ; s/_/ /g')
+              last_prerelease_date=$(date -d"${last_prerelease_formatted}")
+              echo "last prerelease date: ${last_prerelease_date}"
               popd
               
-              echo ::set-output name=changes::$(git log --after="${last_beta_date}" --oneline | wc -l)
+              echo ::set-output name=changes::$(git log --after="${last_prerelease_date}" --oneline | wc -l)
               
-              release_notes="$(git log --after=\\"${last_beta_date}\\" --oneline | sed 's|^|${{ steps.full_name.outputs.full_name }}@|g')"
+              release_notes="$(git log --after=\\"${last_prerelease_date}\\" --oneline | sed 's|^|${{ steps.full_name.outputs.full_name }}@|g')"
               
               # The below lines translate linebreaks so they can be set into the 'release_notes' variable
               release_notes="${release_notes//'%'/'%25'}"
@@ -60,10 +60,10 @@ jobs:
           with:
             token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
             repository: ${{ steps.full_name.outputs.full_name }}
-            event-type: release-beta
+            event-type: release-prerelease
             client-payload: |
                {
-                 "release_tag" : "beta-${{steps.date.outputs.date}}",
+                 "release_tag" : "prerelease-${{steps.date.outputs.date}}",
                  "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
                }
             

--- a/Makefile
+++ b/Makefile
@@ -131,5 +131,5 @@ docker-image-push:
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:
-	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --env-file .env --rm --user $(UID):$(GID) $(DEVELOPER_SETTINGS) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
+	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --init --env-file .env --rm --user $(UID):$(GID) $(DEVELOPER_SETTINGS) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
 

--- a/packages/351elec/sources/scripts/351elec-upgrade
+++ b/packages/351elec/sources/scripts/351elec-upgrade
@@ -16,8 +16,8 @@ fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
-  if [ "$BAND" == "beta" ]; then
-    REPO=351ELEC-beta
+  if [ "$BAND" == "prerelease" ] || [ "$BAND" == "beta" ]; then
+    REPO=351ELEC-prerelease
   else
     REPO=351ELEC
   fi

--- a/packages/351elec/sources/scripts/updatecheck
+++ b/packages/351elec/sources/scripts/updatecheck
@@ -12,8 +12,8 @@ fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
-  if [ "$BAND" == "beta" ]; then
-    REPO=351ELEC-beta
+  if [ "$BAND" == "prerelease" ] || [ "$BAND" == "beta" ]; then
+    REPO=351ELEC-prerelease
   else
     REPO=351ELEC
   fi

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-present Fewtarius
 
 PKG_NAME="351elec-emulationstation"
-PKG_VERSION="ffe39fe1326a88cdd86428dce88bd67697f85ffc"
+PKG_VERSION="cda2c543676c4fb023ea6fc4022aaa0033b07cf8"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
# Summary
See this for more info: https://github.com/351ELEC/351ELEC/pull/724 - at a minimum since `dev` is now the main branch, that change needs to be in dev for it to be enabled by default (scheduled and shown in the UI, etc)  

Above and beyond https://github.com/351ELEC/351ELEC/pull/724, this change adds the machinery to hard code the branch for 'pre-releases' and 'betas' to be 'main' (whereas with the switch to 'dev' as default branch, it would have come from dev).  Changes for this is: https://github.com/351ELEC/351ELEC/commit/1b49abf37022242ac224ceb4cf87427329b37660