### PR TITLE
Update release-prerelease.yaml

### DIFF
--- a/.github/workflows/release-prerelease.yaml
+++ b/.github/workflows/release-prerelease.yaml
@@ -38,7 +38,7 @@ jobs:
               # looking for commits in 351ELEC newer than that date
               git clone https://github.com/${{ steps.full_name.outputs.full_name }}-prerelease prerelease
               pushd prerelease
-              last_tag=$(git tag -l | tail -1)
+              last_tag=$(git tag -l | grep "prerelease-" | tail -1)
               last_prerelease_formatted=$(echo ${last_tag} | sed 's/prerelease-//g ; s/_/ /g')
               last_prerelease_date=$(date -d"${last_prerelease_formatted}")
               echo "last prerelease date: ${last_prerelease_date}"


### PR DESCRIPTION
# Summary
Just a small fix to ensure when pre-release process is looking for the last prerelease it doesn't pull in 'beta-' releases as the logic will choke on it.

This can be worked around by making a 'fake' pre-release for it to find, but better to be defensive.  We already do this for the 'beta-' releases.