### PR TITLE
Reverting np2kai to last version where savestates worked

### DIFF
--- a/config/blocklist
+++ b/config/blocklist
@@ -1,1 +1,2 @@
 amiberry # releases 4.x don't work, needs testing if reenabled
+np2kai # Last major commit before hiatus is broken

--- a/packages/games/libretro/np2kai/package.mk
+++ b/packages/games/libretro/np2kai/package.mk
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="np2kai"
-PKG_VERSION="3e8fedc7c1c6f68faa26589187512474a766ee9e"
-PKG_SHA256="df1088e405b5a9f316d64414e91a49ebb2965110a5714c6413b980dd95b4a967"
+PKG_VERSION="910ab3f636af8d159c85464029f3e59b1a835374"
+PKG_SHA256="7fc2f52d7297b3707b3cc7868fae06d08a32a48d782ade8ab293bd0f7cd399d5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/ui/351elec-emulationstation/config/es_features.cfg
+++ b/packages/ui/351elec-emulationstation/config/es_features.cfg
@@ -101,7 +101,7 @@
       <core name="neocd" features="netplay, rewind, autosave" />
       <core name="nestopiaCV" features="netplay, rewind, autosave" />
       <core name="nestopia" features="netplay, rewind, autosave, cheevos" />
-      <core name="np2kai" features="netplay, rewind" />
+      <core name="np2kai" features="netplay, rewind, autosave" />
       <core name="nxengine" features="netplay, rewind, autosave" />
       <core name="o2em" features="netplay, rewind, autosave, cheevos" />
       <core name="opera" features="netplay, rewind, autosave, cheevos" />


### PR DESCRIPTION
The last major commit on np2kai wasn't fully debugged before the maintainer went on hiatus, so it has lingering issues that make it unstable. Not only can it not use savestates, it crashes from savestate attempts.

I'm not sure what actual benefits this last major commit has. It might be possible to patch it and re-integrate it, but for now I think it's best to move back to a more stable version.