### PR TITLE
Enable Version-Specific Post Updates

### DIFF
--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -25,8 +25,8 @@ if [[ -f "${LAST_UPDATE_FILE}" ]]; then
   # Prerelease: prerelease-20211130_1728
   # Release: 20211122
   # Release - patch: 20211122-1
-  PATTERN="s|.*([0-9]{8}).*|\1|g"
-  LAST_UPDATE_VERSION="$(cat "$LAST_UPDATE_FILE" | grep -E "$PATTERN" sed -E "s|$PATTERN|\1|g" )"
+  PATTERN='.*([0-9]{8}).*'
+  LAST_UPDATE_VERSION="$(cat "$LAST_UPDATE_FILE" | grep -E "$PATTERN" | sed -E "s|$PATTERN|\1|g" )"
   
   # If we cannot parse last update version - set to large date that will never execute - this prevents dev versions causing strangeness
   if [[ -z "${LAST_UPDATE_VERSION}" ]]; then
@@ -87,31 +87,31 @@ sed -i '/global.bezel=0/d;
 ### - Doing this after other bezel changes from 2021-10-04 so empty values are consistent for upgrades prior to pineapple forrest.
 ### - Only running for versions less than current date - this ensures if user sets to 'auto' after upgrade, settings will be 'off' as desired
 if [[ "$LAST_UPDATE_VERSION" -le "20211215" ]]; then
-  grep -qx 'global.bezel=' "${CONF}"|| echo 'global.bezel=default"' >> "${CONF}"
+  grep -qF 'global.bezel=' "${CONF}"|| echo 'global.bezel=default' >> "${CONF}"
 
-  grep -qx 'gamegear.bezel.overlay.grid=' "${CONF}"|| echo 'gamegear.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'gamegear.bezel.overlay.shadow=' "${CONF}"|| echo 'gamegear.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'gamegear.bezel.overlay.grid=' "${CONF}"|| echo 'gamegear.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'gamegear.bezel.overlay.shadow=' "${CONF}"|| echo 'gamegear.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'gb.bezel.overlay.grid=' "${CONF}"|| echo 'gb.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'gb.bezel.overlay.shadow=' "${CONF}"|| echo 'gb.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'gb.bezel.overlay.grid=' "${CONF}"|| echo 'gb.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'gb.bezel.overlay.shadow=' "${CONF}"|| echo 'gb.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'gbc.bezel.overlay.grid=' "${CONF}"|| echo 'gbc.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'gbc.bezel.overlay.shadow=' "${CONF}"|| echo 'gbc.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'gbc.bezel.overlay.grid=' "${CONF}"|| echo 'gbc.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'gbc.bezel.overlay.shadow=' "${CONF}"|| echo 'gbc.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'ngp.bezel.overlay.grid=' "${CONF}"|| echo 'ngp.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'ngp.bezel.overlay.shadow=' "${CONF}"|| echo 'ngp.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'ngp.bezel.overlay.grid=' "${CONF}"|| echo 'ngp.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'ngp.bezel.overlay.shadow=' "${CONF}"|| echo 'ngp.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'ngpc.bezel.overlay.grid=' "${CONF}"|| echo 'ngpc.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'ngpc.bezel.overlay.shadow=' "${CONF}"|| echo 'ngpc.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'ngpc.bezel.overlay.grid=' "${CONF}"|| echo 'ngpc.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'ngpc.bezel.overlay.shadow=' "${CONF}"|| echo 'ngpc.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'pokemini.bezel.overlay.grid=' "${CONF}"|| echo 'pokemini.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'pokemini.bezel.overlay.shadow=' "${CONF}"|| echo 'pokemini.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'pokemini.bezel.overlay.grid=' "${CONF}"|| echo 'pokemini.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'pokemini.bezel.overlay.shadow=' "${CONF}"|| echo 'pokemini.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'supervision.bezel.overlay.grid=' "${CONF}"|| echo 'supervision.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'supervision.bezel.overlay.shadow=' "${CONF}"|| echo 'supervision.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'supervision.bezel.overlay.grid=' "${CONF}"|| echo 'supervision.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'supervision.bezel.overlay.shadow=' "${CONF}"|| echo 'supervision.bezel.overlay.shadow=1' >> "${CONF}"
 
-  grep -qx 'wonderswan.bezel.overlay.grid=' "${CONF}"|| echo 'wonderswan.bezel.overlay.grid=1"' >> "${CONF}"
-  grep -qx 'wonderswan.bezel.overlay.shadow=' "${CONF}"|| echo 'wonderswan.bezel.overlay.shadow=1"' >> "${CONF}"
+  grep -qF 'wonderswan.bezel.overlay.grid=' "${CONF}"|| echo 'wonderswan.bezel.overlay.grid=1' >> "${CONF}"
+  grep -qF 'wonderswan.bezel.overlay.shadow=' "${CONF}"|| echo 'wonderswan.bezel.overlay.shadow=1' >> "${CONF}"
 fi
 
 ## 2021-09-30:
@@ -260,7 +260,7 @@ fi
 echo Last Update: `date -Iminutes` > /storage/.lastupdate
 
 ## Allows only performing updates from specific versions
-echo Last Update: $(cat /storage/.config/.OS_VERSION) > "${LAST_UPDATE_FILE}"
+echo $(cat /storage/.config/.OS_VERSION) > "${LAST_UPDATE_FILE}"
 
 # Clear Executing postupdate... message
 echo -ne "\033[$1;$1H" >/dev/console

--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -5,6 +5,32 @@
 ## Config Files
 CONF="/storage/.config/distribution/configs/distribution.conf"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
+LAST_UPDATE_FILE="/storage/.lastupdateversion"
+
+LAST_UPDATE_VERSION="0"
+if [[ -f "${LAST_UPDATE_FILE}" ]]; then
+
+  #The following parsing should work for all the below permuations: (anything with 8 digits as a date)
+  #
+  # PR: pr-740-2021-12-04-20211208_1753-3781bcc
+  # Beta: beta-20211130_1728
+  # Prerelease: prerelease-20211130_1728
+  # Release: 20211122
+  # Release - patch: 20211122-1
+  PATTERN="s|.*([0-9]{8}).*|\1|g"
+  LAST_UPDATE_VERSION="$(cat "$LAST_UPDATE_FILE" | grep -E "$PATTERN" sed -E "s|$PATTERN|\1|g" )"
+  
+  # If we cannot parse last update version - set to large date that will never execute - this prevents dev versions causing strangeness
+  if [[ -z "${LAST_UPDATE_VERSION}" ]]; then
+    LAST_UPDATE_VERSION="99999999"
+  fi
+fi
+echo "last update version: ${LAST_UPDATE_VERSION}"
+
+# For changes that should only be run if upgrading "Pineapple Forest" - use PR's date to include betas/prerelease before this change
+if [[ "$LAST_UPDATE_VERSION" -le "20211213" ]]; then
+  echo "Running update"
+fi
 
 # 2021-11-03 (konsumschaf)
 # Remove the 2 minutes popup setting from distribution.conf
@@ -196,6 +222,9 @@ fi
 
 ## Just to know when the last update took place
 echo Last Update: `date -Iminutes` > /storage/.lastupdate
+
+## Allows only performing updates from specific versions
+echo Last Update: $(cat /storage/.config/.OS_VERSION) > "${LAST_UPDATE_FILE}"
 
 # Clear Executing postupdate... message
 echo -ne "\033[$1;$1H" >/dev/console

--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -7,6 +7,14 @@ CONF="/storage/.config/distribution/configs/distribution.conf"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
 LAST_UPDATE_FILE="/storage/.lastupdateversion"
 
+
+# 2021-12-15
+## Parse LAST_UPDATE_VERSION.  This variable will be the date of the previous upgrade. Ex: 20211222.
+## - This variable can be used to execute upgrade logic only when crossing a version threshold.
+##   - Greater than/less than checks should always be used to avoid assuming a user is coming from a specific version.
+##   - Logic should still work if run multiple times in case of upgrade/downgrade/upgrade scenario.
+## - For versions prior to the addition of .lastupdateversion (pineapple forest, etc), this number will be 0.
+## - For versions which can't be parsed (custom builds), the number will be set to all 9's so it is greater than all dates
 LAST_UPDATE_VERSION="0"
 if [[ -f "${LAST_UPDATE_FILE}" ]]; then
 
@@ -26,11 +34,6 @@ if [[ -f "${LAST_UPDATE_FILE}" ]]; then
   fi
 fi
 echo "last update version: ${LAST_UPDATE_VERSION}"
-
-# For changes that should only be run if upgrading "Pineapple Forest" - use PR's date to include betas/prerelease before this change
-if [[ "$LAST_UPDATE_VERSION" -le "20211213" ]]; then
-  echo "Running update"
-fi
 
 # 2021-11-03 (konsumschaf)
 # Remove the 2 minutes popup setting from distribution.conf
@@ -77,6 +80,39 @@ sed -i '/global.bezel=0/d;
         /pokemini.bezel=351ELEC-PokemonMini/d;
         /supervision.bezel=351ELEC-Supervision/d;
         ' /storage/.config/distribution/configs/distribution.conf
+
+## 2021-12-15
+## Do not break automatic bezel support for users upgrading from pineapple forrest.
+## Pineapple Forest bezels assumed 'auto' would mean 'on', but should be 'off'
+### - Doing this after other bezel changes from 2021-10-04 so empty values are consistent for upgrades prior to pineapple forrest.
+### - Only running for versions less than current date - this ensures if user sets to 'auto' after upgrade, settings will be 'off' as desired
+if [[ "$LAST_UPDATE_VERSION" -le "20211215" ]]; then
+  grep -qx 'global.bezel=' "${CONF}"|| echo 'global.bezel=default"' >> "${CONF}"
+
+  grep -qx 'gamegear.bezel.overlay.grid=' "${CONF}"|| echo 'gamegear.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'gamegear.bezel.overlay.shadow=' "${CONF}"|| echo 'gamegear.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'gb.bezel.overlay.grid=' "${CONF}"|| echo 'gb.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'gb.bezel.overlay.shadow=' "${CONF}"|| echo 'gb.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'gbc.bezel.overlay.grid=' "${CONF}"|| echo 'gbc.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'gbc.bezel.overlay.shadow=' "${CONF}"|| echo 'gbc.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'ngp.bezel.overlay.grid=' "${CONF}"|| echo 'ngp.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'ngp.bezel.overlay.shadow=' "${CONF}"|| echo 'ngp.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'ngpc.bezel.overlay.grid=' "${CONF}"|| echo 'ngpc.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'ngpc.bezel.overlay.shadow=' "${CONF}"|| echo 'ngpc.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'pokemini.bezel.overlay.grid=' "${CONF}"|| echo 'pokemini.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'pokemini.bezel.overlay.shadow=' "${CONF}"|| echo 'pokemini.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'supervision.bezel.overlay.grid=' "${CONF}"|| echo 'supervision.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'supervision.bezel.overlay.shadow=' "${CONF}"|| echo 'supervision.bezel.overlay.shadow=1"' >> "${CONF}"
+
+  grep -qx 'wonderswan.bezel.overlay.grid=' "${CONF}"|| echo 'wonderswan.bezel.overlay.grid=1"' >> "${CONF}"
+  grep -qx 'wonderswan.bezel.overlay.shadow=' "${CONF}"|| echo 'wonderswan.bezel.overlay.shadow=1"' >> "${CONF}"
+fi
 
 ## 2021-09-30:
 ## Remove any configurd ES joypads on upgrade


### PR DESCRIPTION
# tl;dr for developers
Inside the `postupdate.sh` script, we now parse a variable `LAST_UPDATE_VERSION`.  This value can be used to run if upgrading from below a certain version in an if statement.  Ex:

```
if [[ "$LAST_UPDATE_VERSION" -le "20211122" ]]; then
  echo "Only run when upgrading from pineapple forest or older"
fi
```

**NOTE**: `LAST_UPDATE_VERSION` should be only used if always running the upgrades in `postupdate.sh` - as done today -  is not an option.  This helps to keep things simpler.

# Background
https://github.com/351ELEC/351ELEC/pull/740 redoes `setsettings.sh` with python for performance/maintainability and discovered that bezels did not follow convention of all other settings which is: "If a setting is 'auto' in game settings, system settings and game override settings, it should be 'off' ".  "Currated" 351ELEC defaults are set in `distribution.conf` and those defaults will be visible in ES and not set to 'auto'.

In new deployments, it's an easy fix to just ship a new `distribution.conf` file which contains bezel settings explicitly set instead of assuming they can be default `on`.  But it brings up an issue when trying to do the same in the upgrade as the entire `postupdate.sh` script is run on every upgrade:
- There's no way to tell if a user intentionally set a value to `auto` (in which case we shouldn't add the explicit value) or if the user is upgrading from Pineapple Forest and just didn't have the value set (we should add the explicit value)
- The only way to cleanly fix this is to introduce a mechanism to only run parts of `postupdate.sh` if a user is upgrading from below a certain version.

# Summary
This change keeps track of the 'last version' in a file `~/.lastupdateversion`.  The version is set at the end of the `postupdate` script.  This contains the full version (`20211122` or `prereleaase-20211011_2001`, etc)

### LAST_UPDATE_VERSION Logic
`LAST_UPDATE_VERSION` is a variable future updates in `postupdate.sh` can utilize to only run upgrades when coming from below a specific version.  NOTE: It is strongly suggested to **always** use "less than" (`-lt`) or "less than equals" (`-le`) when checking against this variable (and not "equals") so we do not depend on a user upgrading from a specific version.

  - If the `~/.lastupdateversion` file does not exist, the value of LAST_UPDATE_VERSION will be 0.  This allows a "less than or equals" (`-le`) to work normally from versions without this change.  NOTE: This will be the case for Pineapple Forest (`LAST_UPDATE_VERISON=0`), however, using a real date in if statements (`-le 20211122`) is preferred for clarity and to set the precedent for how to do future checks.
    - This also means just removing the file (`~/.lastupdateversion` ) will cause all upgrade logic to rerun on next update, which may be useful.
  - If the `~/.lastupdateversion` file exists, we simply look for any 8 digits in a row (`20211122`) and use that as LAST_UPDATE_VERSION.
    -  This should work for all version types I know of. 
       - **PR**: `pr-740-2021-12-04-20211208_1753-3781bcc`
       - **Beta**: `beta-20211130_1728`
       - **Prerelease**: `prerelease-20211130_1728`
       - **Release**: `20211122`
       - **Release** - patch: `20211122-1`
  - If for some reason, we can't parse a version (Ex: `CUSTOM_VERSION=my-dev-build` was used in a local dev build), we set LOCAL_UPDATE_VERSION to `99999999` to ensure any "less than" logic will not run as we don't know the real version.

# Bezel fixes
This mainly just adds the bezel explicit defaults (`global.bezel=default`, `gb.bezel.overlay.shadow=1`, etc) to `distribution.conf` if upgrading from a version less than todays date (`20211215`).  `20211215` was used instead of `20211122` as this allows the initial pre-release and the 'bridge' beta to update cleanly as well as Pineapple Forrest (`20211122`).

The end result of this should be that bezels will appear to work in the same way they did in Pineapple Forest and be on by default (however, some values in ES will switch from `auto` to `on`, etc)