### PR TITLE
Add ability to stop postupdate.sh from clearing /storage/joypads

### DIFF
--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -116,8 +116,9 @@ fi
 
 ## 2021-09-30:
 ## Remove any configurd ES joypads on upgrade
-rm -f /storage/joypads/*.cfg
-
+if [ ! -f /storage/joypads/dont_delete_me ]; then
+  rm -f /storage/joypads/*.cfg
+fi
 
 ## 2021-09-27:
 ## Force replacement of gamecontrollerdb.txt on update


### PR DESCRIPTION
I win! No longer will this annoy me! :joy_cat: If a file called `dont_delete_me` is present in the /storage/joypads folder, all the .cfg files in there won't be deleted on update, and then I can keep my hotkey remappings and other things, and if anyone else ever does this then they can do it too.

If postupdate.sh still does need to remove old .cfg files in there, then that is fine, and it won't break anything, because nobody is going to have a file with that name just accidentally in there. So everybody wins!