### PR TITLE
maxperf, bezels, integer overscale and LaunchBox Importer

### DIFF
--- a/packages/351elec/config/distribution/configs/distribution.conf.351p
+++ b/packages/351elec/config/distribution/configs/distribution.conf.351p
@@ -328,9 +328,3 @@ zxspectrum.ratio=4/3
 zxspectrum.rgascale=1
 zx81.ratio=4/3
 zx81.rgascale=1
-
-# 552 beta defaults to looking for pre-releases
-updates.type=prerelease
-
-# Comment out below line when 351ELEC has normal prereleases/releases for 552 and beta is no longer needed
-updates.github.repo=552_beta

--- a/packages/351elec/config/distribution/configs/distribution.conf.351v
+++ b/packages/351elec/config/distribution/configs/distribution.conf.351v
@@ -92,6 +92,9 @@ updates.type=release
 ## The global value will be used for all emulators, except if the value
 ## is redefined in the emulator
 
+## Bezel on by default
+global.bezel=default
+
 ## Retroarch menu driver, ozone (default), rgui or xmb
 global.retroarch.menu_driver=ozone
 
@@ -200,10 +203,16 @@ fbn.ratio=core
 fbn.rgascale=1
 fds.ratio=4/3
 fds.rgascale=1
+gamegear.bezel.overlay.grid=1
+gamegear.bezel.overlay.shadow=1
 gamegear.integerscale=1
+gb.bezel.overlay.grid=1
+gb.bezel.overlay.shadow=1
 gb.integerscale=1
 gba.ratio=3/2
 gbah.ratio=3/2
+gbc.bezel.overlay.grid=1
+gbc.bezel.overlay.shadow=1
 gbc.integerscale=1
 gbch.integerscale=1
 gbh.integerscale=1
@@ -245,7 +254,11 @@ nes.ratio=4/3
 nes.rgascale=1
 nesh.ratio=4/3
 nesh.rgascale=1
+ngp.bezel.overlay.grid=1
+ngp.bezel.overlay.shadow=1
 ngp.integerscale=1
+ngpc.bezel.overlay.grid=1
+ngpc.bezel.overlay.shadow=1
 ngpc.intergerscale=1
 odyssey2.ratio=4/3
 odyssey2.rgascale=1
@@ -261,6 +274,8 @@ pcenginecd.rgascale=1
 pcfx.maxperf=1
 pcfx.ratio=4/3
 pcfx.rgascale=1
+pokemini.bezel.overlay.grid=1
+pokemini.bezel.overlay.shadow=1
 pokemini.ratio=3/2
 psp.maxperf=1
 pspminis.maxperf=1
@@ -284,6 +299,8 @@ snesmsu1.ratio=4/3
 snesmsu1.rgascale=1
 supergrafx.ratio=4/3
 supergrafx.rgascale=1
+supervision.bezel.overlay.grid=1
+supervision.bezel.overlay.shadow=1
 supervision.integerscale=1
 tg16.ratio=4/3
 tg16.rgascale=1
@@ -299,7 +316,11 @@ videopac.ratio=4/3
 videopac.rgascale=1
 virtualboy.integerscale=1
 virtualboy.maxperf=1
+wonderswan.bezel.overlay.grid=1
+wonderswan.bezel.overlay.shadow=1
 wonderswan.integerscale=1
+wonderswancolor.bezel.overlay.grid=1
+wonderswancolor.bezel.overlay.shadow=1
 wonderswancolor.integerscale=1
 x68000.ratio=4/3
 x68000.rgascale=1
@@ -307,9 +328,3 @@ zxspectrum.ratio=4/3
 zxspectrum.rgascale=1
 zx81.ratio=4/3
 zx81.rgascale=1
-
-# 552 beta defaults to looking for pre-releases
-updates.type=prerelease
-
-# Comment out below line when 351ELEC has normal prereleases/releases for 552 and beta is no longer needed
-updates.github.repo=552_beta

--- a/packages/351elec/config/distribution/configs/distribution.conf.552
+++ b/packages/351elec/config/distribution/configs/distribution.conf.552
@@ -203,6 +203,7 @@ psp.maxperf=1
 psp.ratio=squarepixel
 pspminis.maxperf=1
 pspminis.ratio=squarepixel
+psx.integerscaleoverscale=1
 saturn.ratio=squarepixel
 segacd.ratio=squarepixel
 supervision.ratio=squarepixel

--- a/packages/351elec/sources/scripts/setsettings.py
+++ b/packages/351elec/sources/scripts/setsettings.py
@@ -398,6 +398,12 @@ def set_settings(rom_name: str, core: str, platform: str, controllers: str, auto
     # Auto Frame Relay
     ra_append_dict['video_frame_delay_auto'] = config.get_bool_string("video_frame_delay_auto")
 
+    # maxperf / CPU Governor
+    if config.get_setting('maxperf'):
+        ra_append_dict['cpu_scaling_mode'] = '2'
+    else:
+        ra_append_dict['cpu_scaling_mode'] = '4'
+
     #
     # Settings for special cores
     #
@@ -476,33 +482,54 @@ def set_settings(rom_name: str, core: str, platform: str, controllers: str, auto
     # List of possible Bezel Folders
     bezel_dir = ('/tmp/overlays/bezels', '/storage/roms/bezels')
     # Define the resolutions of the different systems (0:x 1:y 2:width 3:height) as seen in Scaling -> Aspect Ration -> Custom
-    # RG351P/M=480x320
-    # RG351V/MP=640x480
+    # Devices (width x hight)
+    #   RG351P/M = 480x320
+    #   RG351V/MP = 640x480
+    #   RG552 = 1920x1152
+    # Consoles (width x hight)
+    #   GB/GBC/GG = 160x144
+    #   supervision = 160x160
+    #   Pokemini = 96x64
+    #   ngp/ngpc = 160x152
+    #   wonderswan/wonderswancolor = 224×144
     if device_name == "RG351P":
         system_viewport = {
-            'standard': (1, 1, 479, 319),
-            'gb': (80, 16, 320, 288),
-            'gbc': (80, 16, 320, 288),
-            'supervision': (80, 0, 320, 320),
-            'gamegear': (80, 16, 320, 288),
-            'pokemini': (96, 64, 288, 192),
-            'ngp': (80, 8, 320, 304),
-            'ngpc': (80, 8, 320, 304),
-            'wonderswan': (16, 16, 448, 288),
-            'wonderswancolor': (16, 16, 448, 288),
+            'standard': (1, 1, 479, 319),          # max-1
+            'gb': (80, 16, 320, 288),              # x2
+            'gbc': (80, 16, 320, 288),             # x2
+            'supervision': (80, 0, 320, 320),      # x2
+            'gamegear': (80, 16, 320, 288),        # x2
+            'pokemini': (96, 64, 288, 192),        # x3
+            'ngp': (80, 8, 320, 304),              # x2
+            'ngpc': (80, 8, 320, 304),             # x2
+            'wonderswan': (16, 16, 448, 288),      # x2
+            'wonderswancolor': (16, 16, 448, 288), # x2
         }
-    else: # Must be the V or MP then
+    elif device_name == "RG351V" or device_name == "RG351MP":
         system_viewport = {
-            'standard': (1, 1, 639, 479),
-            'gb': (80, 24, 480, 432),
-            'gbc': (80, 24, 480, 432),
-            'supervision': (80, 0, 480, 480),
-            'gamegear': (80, 24, 480, 432),
-            'pokemini': (128, 112, 384, 256),
-            'ngp': (80, 12, 480, 456),
-            'ngpc': (80, 12, 480, 456),
-            'wonderswan': (96, 96, 448, 288),
-            'wonderswancolor': (96, 96, 448, 288),
+            'standard': (1, 1, 639, 479),          # max-1
+            'gb': (80, 24, 480, 432),              # x3
+            'gbc': (80, 24, 480, 432),             # x3
+            'supervision': (80, 0, 480, 480),      # x3
+            'gamegear': (80, 24, 480, 432),        # x3
+            'pokemini': (128, 112, 384, 256),      # x4
+            'ngp': (80, 12, 480, 456),             # x3
+            'ngpc': (80, 12, 480, 456),            # x3
+            'wonderswan': (96, 96, 448, 288),      # x2
+            'wonderswancolor': (96, 96, 448, 288), # x2
+        }
+    elif device_name == "RG552":
+        system_viewport = {
+            'standard': (1, 1, 1919, 1151),         # max-1
+            'gb': (320, 0, 1280, 1152),             # x8
+            'gbc': (320, 0, 1280, 1152),            # x8
+            'supervision': (400, 16, 1120, 1120),   # x7
+            'gamegear': (320, 0, 1280, 1152),       # x8
+            'pokemini': (96, 0, 1728, 1152),        # x18
+            'ngp': (400, 44, 1120, 1064),           # x7
+            'ngpc': (400, 44, 1120, 1064),          # x7
+            'wonderswan': (64, 0, 1792, 1152),      # x8
+            'wonderswancolor': (64, 0, 1792, 1152), # x8
         }
 
     if (bezel := config.get_setting('bezel')) and platform in system_viewport:

--- a/packages/tools/klbi/package.mk
+++ b/packages/tools/klbi/package.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 PKG_NAME="klbi"
-PKG_VERSION="47fdeec0a3260fc3e39f81b6a07eddcfbb2689fe"
+PKG_VERSION="c1de59df5fd7ac64fba9401906d5823e6995bbea"
 PKG_GIT_CLONE_BRANCH="main"
 PKG_REV="1"
 PKG_ARCH="any"


### PR DESCRIPTION
* maxperf support for setsettings to override RA defaults
* prepare bezels for the RG552
* add bezel defaults for the RG351V/MP
* set integer overscale as default for psx on the RG552
* new version of LaunchBox Importer to support scrap-as fallback for unknown systems