### PR TITLE
Limit fan control service enabled to 552

### DIFF
--- a/packages/351elec/package.mk
+++ b/packages/351elec/package.mk
@@ -107,7 +107,9 @@ post_install() {
   cp -r $PKG_DIR/gamepads/* $INSTALL/etc/retroarch-joypad-autoconfig
   ln -sf 351elec.target $INSTALL/usr/lib/systemd/system/default.target
   enable_service 351elec-autostart.service
-  enable_service fan_control.service
+  if [[ "${DEVICE}" == "RG552" ]]; then
+    enable_service fan_control.service
+  fi
 
   echo "" >$INSTALL/etc/issue
   echo "  _________  _ _____ _     _____ ____ " >>$INSTALL/etc/issue


### PR DESCRIPTION
# Summary 
Only enable fan control on 552.  Still need to double check this on 351 devices, but seems so simple it likely works.