### PR TITLE
Fix runemu.py error when ES sends `-state_slot -99`

### DIFF
--- a/packages/351elec/sources/scripts/runemu.py
+++ b/packages/351elec/sources/scripts/runemu.py
@@ -244,7 +244,7 @@ def main():
 
 	i = 0
 	args: dict[str, str] = {}
-	while i < len(sys.argv):
+	while i < len(sys.argv)-1:
 		if sys.argv[i].startswith('--'):
 			args[sys.argv[i][2:]] = sys.argv[i + 1]
 			i += 1


### PR DESCRIPTION
Issue:
- works: A game has no saves states and user press "Start new game" or "Start Auto Save" in ES
- doesn't work: a game with only an auto save (And user presses either 'Start new game' or 'Auto Save')
- works: a game with an auto save and manual saves.  (Start new game, Auto Save, or picking a manual save all work)

This is because ES sends `-stat_slot -99` and the current code attempts to parse `-99` as an argument.

The following error is seen in logs:
```
Traceback (most recent call last):
  File "/usr/bin/runemu.py", line 324, in <module>
    main()
  File "/usr/bin/runemu.py", line 253, in main
    args[sys.argv[i][1:]] = sys.argv[i + 1]
IndexError: list index out of range
```

Fix:
- Because all arguments to runemu.py have values (`-state_slot 0` and not just `-state_slot`) we can assume that the last argument in the list does not need to be parsed (ex: `-state_slot 0` reads the value `0` when looking at `-state_slot`.  This avoids the confusion where the code things `-99` is an argument and tries to parse it's value (which doesn't exist)

Summary: I would describe this as a 'band-aid' fix.  I think it works and deals with the edge cases we have - but there's probably some 'better' way to fix argument parsing longer term.