### PR TITLE
Add support for dev release similar to prerelease - developers only

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,7 +1,7 @@
 name: build-main
 on:
   repository_dispatch:
-    types: [release-beta, release-prerelease, release-draft]
+    types: [release-beta, release-prerelease, release-draft, release-dev]
   workflow_dispatch:
   push:
     paths-ignore:
@@ -156,6 +156,45 @@ jobs:
           prerelease: true
           token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
           repo: 351ELEC-prerelease
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+      - name: Create dev release as draft at first to hide during uploads
+        if: github.event.action == 'release-dev'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          body: |
+            # Release Notes (Dev - Unsuppported)
+            This is an **unsupported dev release** based on the commit: ${{ github.event.repository.full_name }}@${{github.sha}}.
+
+            Unless you were asked by a developer to use this build or **are** a developer.  **Do not use this build.**
+            
+            ### Changes (since last dev build):
+            ${{ github.event.client_payload.release_notes }}
+            
+            ### Upgrade Instructions
+            You can update to this release using the `prerelease` channel on your device if you take the following steps:
+            - Under`System Settings` -> `Developer` (`Updates` section), set the following:
+              -`GITHUB ORG` = `351dev`
+              -`GITHUB REPO` = `builds`
+
+          artifacts: "release/aarch64/RG351P/*, release/aarch64/RG351V/*, release/aarch64/RG351MP/*, release/aarch64/RG552/*"
+          prerelease: true
+          draft: true
+          token: ${{ secrets.TRIGGER_DEV_BUILD_TOKEN }}
+          owner: 351dev
+          repo: dev-builds
+      - name: Switch draft to start showing release 
+        if: github.event.action == 'release-dev'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.version.outputs.version }}"
+          allowUpdates: true
+          draft: false
+          prerelease: true
+          token: ${{ secrets.TRIGGER_DEV_BUILD_TOKEN }}
+          owner: 351dev
+          repo: dev-builds
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,0 +1,79 @@
+
+# The purpose of this build is to allow a 'dev' release be created.  
+# dev releases are unsupported and should only be used by developers or at the request of a developer
+#  Typically, it will be created every day if there are new commits since the last tag
+#  It can also be run manually.
+name: release-dev
+on:
+  schedule:
+    - cron:  '0 5 * * *' # Have ready for beginning of day in Europe where most devs are.
+      
+  workflow_dispatch:  # allows manual runs
+env:
+  BRANCH: dev
+
+jobs:
+  launch-dev-release-if-needed:
+      runs-on: ubuntu-20.04
+      steps:
+        #- uses: hmarr/debug-action@v2
+        #  name: debug
+        - uses: actions/checkout@v2
+          name: checkout
+          with:
+            clean: false
+            fetch-depth: 0
+            ref: "${{env.BRANCH}}"
+            
+        # We get the full name from git here as in the case of 'cron', it is not available on the event
+        - name: repository full name
+          id: dev_builds_full_name
+          run: |
+               echo "::set-output name=full_name::351dev/dev-builds"
+        - name: repository full name
+          id: full_name
+          run: |
+               echo "::set-output name=full_name::$(git config --get remote.origin.url | sed 's|^.*github.com/||g' | sed 's/.git$//g')"
+        
+        - name: changes
+          id: changes
+          run: |
+          
+              #Figure out last dev build date by converting the latest 351dev/dev-builds tag into a date and 
+              # looking for commits in 351ELEC newer than that date
+              git clone https://github.com/${{ steps.dev_builds_full_name.outputs.full_name }} dev
+              pushd dev
+              last_tag=$(git tag -l | grep "dev-" | tail -1)
+              last_dev_formatted=$(echo ${last_tag} | sed 's/dev-//g ; s/_/ /g')
+              last_dev_date=$(date -d"${last_dev_formatted}")
+              echo "last dev date: ${last_dev_date}"
+              popd
+              
+              echo ::set-output name=changes::$(git log --after="${last_dev_date}" --oneline | wc -l)
+              
+              release_notes="$(git log --after=\\"${last_dev_date}\\" --oneline | sed 's|^|${{ steps.full_name.outputs.full_name }}@|g')"
+              
+              # The below lines translate linebreaks so they can be set into the 'release_notes' variable
+              release_notes="${release_notes//'%'/'%25'}"
+              release_notes="${release_notes//$'\n'/'%0A'}"
+              release_notes="${release_notes//$'\r'/'%0D'}"
+
+              echo "::set-output name=release_notes::${release_notes}"
+        - name: Get date for artifacts
+          id: date
+          run: echo "::set-output name=date::$(date +'%Y%m%d_%H%M')"
+  
+        - name: Repository Dispatch
+          if: steps.changes.outputs.changes != '0'
+          uses: peter-evans/repository-dispatch@v1
+          with:
+            token: ${{ secrets.TRIGGER_BUILD_TOKEN }}
+            repository: ${{ steps.full_name.outputs.full_name }}
+            event-type: release-dev
+            client-payload: |
+               {
+                 "branch" : "${{ env.BRANCH }}",
+                 "release_tag" : "dev-${{steps.date.outputs.date}}",
+                 "release_notes" : ${{toJSON(steps.changes.outputs.release_notes)}}
+               }
+            

--- a/packages/351elec/sources/scripts/get-release.py
+++ b/packages/351elec/sources/scripts/get-release.py
@@ -361,7 +361,7 @@ def get_args():
                         help='Github repository. Allows testing with repo releases other than 351ELEC')
     parser.add_argument('--band',
                         default="release",
-                        choices=['release', 'beta', 'prerelease', 'daily'],
+                        choices=['release', 'beta', 'prerelease', 'daily', 'dev'],
                         help='''Update "band" ("channel"). Allows determining what latest release to get. 
                              "daily" is for backwards compatibility and maps to "release"
                              "beta" is for backwards compatibility and will map to 'prerelease'
@@ -418,6 +418,8 @@ def get_args():
     #TODO: If we end up with a lot of different bands - we may need to refactor this in the future
     if not existing_release:
       existing_release = parse_release(args.existing_release, "beta")
+    if not existing_release:
+      existing_release = parse_release(args.existing_release, "dev")
     args.existing_release = existing_release
     return args
 
@@ -478,6 +480,11 @@ def get_current_release(org, repo, band, page=0, per_page=100):
     if band == "prerelease" and current_release == None:
         for release in releases:
             tag_name = parse_release(release['tag_name'], "beta")
+            if tag_name:
+                current_release = tag_name
+                break
+        for release in releases:
+            tag_name = parse_release(release['tag_name'], "dev")
             if tag_name:
                 current_release = tag_name
                 break


### PR DESCRIPTION
**Summary**: Dev releases will be published daily as needed - similar to 'prereleases'.  Dev releases are **not** intended for public consumption.

Releases will be published to https://github.com/351dev/builds.  This is **outside** the 351ELEC organization to make it 100% clear that this is not something that is supported for anyone other than developers or people working with developers.

Online updates will be possible by:
  - Under `System Settings` -> `Developer` (`Updates` section), set the following:
    -`GITHUB ORG` = `351dev`
    -`GITHUB REPO` = `builds`

NOTE: You will no longer get normal online updates if you use this process until you blank out GITHUB_ORG and GITHUB_REPO.

This change also makes releases that start 'dev-*' as valid releases. In the case of multiple types of releases in a single repository, precendence will be given to: `prerelease`, then `beta`, then `dev`.  So typically `dev` releases should be siloed in their own repository as any `prerelease` or `beta` release will be used instead (no matter how old)