### PR TITLE
Fix volume control to be faster

### DIFF
--- a/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -103,11 +103,13 @@ done
           fi
 
           INCREMENT_AMOUNT=1
-          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
+          if [[ "${REPEAT_NUM}" -gt "10" ]]; then
+             INCREMENT_AMOUNT=10
+          elif [[ "${REPEAT_NUM}" -gt "6" ]]; then
              INCREMENT_AMOUNT=5
-          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
+          elif [[ "${REPEAT_NUM}" -gt "3" ]]; then
              INCREMENT_AMOUNT=2
-          fi   
+          fi
           # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
             ${COMMAND} ${UP} ${INCREMENT_AMOUNT} > /dev/null

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -105,11 +105,13 @@ done
           if [[ "$line" == ${REPEAT_PRESS} && $(( ${REPEAT_NUM} % ${REPEAT_MOD} )) != "0" ]]; then
              continue
           fi
-
+         
           INCREMENT_AMOUNT=1
-          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
+          if [[ "${REPEAT_NUM}" -gt "10" ]]; then
+             INCREMENT_AMOUNT=10
+          elif [[ "${REPEAT_NUM}" -gt "6" ]]; then
              INCREMENT_AMOUNT=5
-          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
+          elif [[ "${REPEAT_NUM}" -gt "3" ]]; then
              INCREMENT_AMOUNT=2
           fi
           # Run the commands to adjust volume/brightness

--- a/projects/Rockchip/devices/RG552/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG552/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -102,12 +102,14 @@ done
              continue
           fi
 
-          INCREMENT_AMOUNT=1
-          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
+         INCREMENT_AMOUNT=1
+          if [[ "${REPEAT_NUM}" -gt "10" ]]; then
+             INCREMENT_AMOUNT=10
+          elif [[ "${REPEAT_NUM}" -gt "6" ]]; then
              INCREMENT_AMOUNT=5
-          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
+          elif [[ "${REPEAT_NUM}" -gt "3" ]]; then
              INCREMENT_AMOUNT=2
-          fi   
+          fi
           # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
             ${COMMAND} ${UP} ${INCREMENT_AMOUNT} > /dev/null


### PR DESCRIPTION
## Summary
Some users have complained that volume control was a bit slow.

I did a bit of research and compared to a Switch and IOS/Android our volume control is indeed much slower.

This change makes the overall much faster when holding down, while still allowing 1% adjustments (helpful for users where sound range due to hardware differences isn't uniform across all 100%) and smaller adjustments if you don't hold very long.

The volume adjustment is still slightly slower than other devices, but I feel it's a good compromise between existing behavior and other systems behavior.