### PR TITLE
Fix sound to use hardware DAC

### DIFF
--- a/packages/351elec/config/asound.conf
+++ b/packages/351elec/config/asound.conf
@@ -1,39 +1,20 @@
-# anbernic-audio alsa config
-# dmix + softvol
-
 pcm.!default {
-        type plug
-        slave.pcm "softvol"
+	type plug
+	slave.pcm "dmixer"
 }
 
-ctl.!default {
-        type hw 
-        card 0
-}
-
-pcm.dmixer {
-        ipc_key 1024
-        type dmix
-        slave {
-            pcm "hw:0,0"
-            period_time 0   
-            period_size 1024
-            buffer_size 4096
-            rate 44100
-        }
-        bindings {
-            0 0
-            1 1
-        }
-}
-
-pcm.softvol {
-        type            softvol
-        slave {
-                pcm         "dmixer"
-        }
-        control {
-                name        "Playback"
-                card        0
-        }
+pcm.dmixer  {
+	type dmix
+	ipc_key 1024
+	slave {
+	    pcm "hw:0,0"
+	    period_time 0
+	    period_size 1024
+	    buffer_size 4096
+	    rate 44100
+	}
+	bindings {
+	    0 0
+	    1 1
+	}
 }

--- a/packages/351elec/sources/scripts/postupdate.sh
+++ b/packages/351elec/sources/scripts/postupdate.sh
@@ -6,7 +6,7 @@
 CONF="/storage/.config/distribution/configs/distribution.conf"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
 LAST_UPDATE_FILE="/storage/.lastupdateversion"
-
+DEVICE="$(cat /storage/.config/.OS_ARCH)"
 
 # 2021-12-15
 ## Parse LAST_UPDATE_VERSION.  This variable will be the date of the previous upgrade. Ex: 20211222.
@@ -34,6 +34,19 @@ if [[ -f "${LAST_UPDATE_FILE}" ]]; then
   fi
 fi
 echo "last update version: ${LAST_UPDATE_VERSION}"
+
+
+## 2022-02-11
+## During the beta period, the RG552 used a 'softvol' plugin for asound due to sound issues in kernel
+## This reverts it as new kernel supports sound playback.  We only want to revert once as it's moderately supported to
+## update your asound.conf manually.
+##
+## Additionally, DAC is the name of playback device instead of Playback, so update that in es_settings.
+if [[ "$DEVICE" == "RG552" && "$LAST_UPDATE_VERSION" -le "20220211" ]]; then
+  cp /usr/config/asound.conf /storage/.config/asound.conf
+  sed -i 's/name="AudioDevice" value="Playback"/name="AudioDevice" value="DAC"/g' /storage/.config/emulationstation/es_settings.cfg
+fi
+
 
 # 2021-11-03 (konsumschaf)
 # Remove the 2 minutes popup setting from distribution.conf

--- a/packages/ui/351elec-emulationstation/package.mk
+++ b/packages/ui/351elec-emulationstation/package.mk
@@ -65,6 +65,11 @@ makeinstall_target() {
         cp -rf $PKG_DIR/config/*.cfg $INSTALL/usr/config/emulationstation
         cp -rf $PKG_DIR/config/scripts $INSTALL/usr/config/emulationstation
 
+    # Set the correct playback device for the RG552 - this makes the 'volume overlay' work
+    if [ "${DEVICE}" = "RG552" ]; then
+		sed -i 's/name="AudioDevice" value="Playback"/name="AudioDevice" value="DAC"/g' $INSTALL/usr/config/emulationstation/es_settings.cfg
+	fi
+
 	# set the correct default theme for P/M or V/MP models
 	# there are both default themes in es_settings.cfg
 	# delete es-theme-art-book-3-2 on V/MP

--- a/projects/Rockchip/devices/RG552/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
+++ b/projects/Rockchip/devices/RG552/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
@@ -59,7 +59,7 @@ MINVOL=0
 	fi
 	[ "$STEPVOL" -ge "$MAXVOL" ] && STEPVOL="$MAXVOL"
 	[ "$STEPVOL" -le "$MINVOL" ] && STEPVOL="$MINVOL"
-	amixer set 'Playback' ${STEPVOL}%
+	amixer set 'DAC' ${STEPVOL}%
 	set_ee_setting "audio.volume" ${STEPVOL}
   fi    
 


### PR DESCRIPTION
# Summary
This is a basic change that removes the softvol plugin of asound.conf as adjusting the `DAC` hardware volume control appears to work.
It might also make sense to try and 'unify' the volume scripts across devices, but that takes more time than I had tonight :-).

## Upgrade
~/.config/asound.conf will be replaced on upgrade (only for RG552) 

~/.config/emulationstation/es_settings.cfg` will have AudioDevice set to DAC on upgrade.