### PR TITLE
Fix backup message to not say 'restore'

### DIFF
--- a/packages/351elec/sources/scripts/emuelec-utils
+++ b/packages/351elec/sources/scripts/emuelec-utils
@@ -94,10 +94,10 @@ esac
 function ee_backup() {
         BACKUPFILE="/storage/roms/backup/351ELEC_BACKUP.zip"
         mkdir -p "/storage/roms/backup"
-	echo -en '\e[20;0H\e[37mPlease wait, restoring system...\e[0m' >/dev/console
 
         case "${1}" in
         "restore")
+                echo -en '\e[20;0H\e[37mPlease wait, restoring system...\e[0m' >/dev/console
                 systemctl stop emustation
                 unzip -o ${BACKUPFILE} -d /
                 /usr/bin/postupdate.sh
@@ -105,6 +105,7 @@ function ee_backup() {
                 systemctl start emustation
         ;;
         "backup")
+                echo -en '\e[20;0H\e[37mPlease wait, backing up system...\e[0m' >/dev/console
                 [ -f "${BACKUPFILE}" ] && rm "${BACKUPFILE}"
                 [ -z "$2" ] && systemctl stop emustation
                 zip -9 -r ${BACKUPFILE} \


### PR DESCRIPTION
# Summary
The was a bug which indicating the system was being restored during backup.  This is somewhat disconcerting to users.

Fix is pretty obviously, make a separate message for backup vs restore.