### PR TITLE
Ensure that the parent directory exists in write_file before appending

### DIFF
--- a/packages/351elec/sources/scripts/setsettings.py
+++ b/packages/351elec/sources/scripts/setsettings.py
@@ -113,6 +113,7 @@ def delete_lines(file_path: str, lines: tuple) -> None:
 
 # Append dictionary to the end of a file
 def write_file(file_path: str, dictionary: dict, separator: str = ' = ', quote_sign: str = '"') -> None:
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
     with open(file_path, "a") as file:
         for (key, value) in dictionary.items():
             file.write(f'{key}{separator}{quote_sign}{value}{quote_sign}\n')


### PR DESCRIPTION
Fixes an issue encountered where GB/GBC games would not launch if the Gambatte core options directory does not exist, e.g. from a fresh flash.