### PR TITLE
Add schedutils (taskset)

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -52,6 +52,7 @@ PKG_CONFIGURE_OPTS_TARGET="${UTILLINUX_CONFIG_DEFAULT} \
                            --enable-libsmartcols \
                            --enable-losetup \
                            --enable-fsck \
+                           --enable-schedutils \
                            --enable-fstrim \
                            --enable-blkid \
                            --enable-lscpu"


### PR DESCRIPTION
Add the 'real' taskset.  Just didn't see how to add it in linux-utils before.  Should have done this way before busybox.