### PR TITLE
Moving piemu executables into /usr/bin

### DIFF
--- a/packages/games/emulators/piemu/bin/piemu.sh
+++ b/packages/games/emulators/piemu/bin/piemu.sh
@@ -30,15 +30,15 @@ if [[ "$EXTENSION" == "pex" ]]; then
 		dos2unix "$GAMEFOLDER/$BASEROMNAME.pfs"
 		cat "$GAMEFOLDER/$BASEROMNAME.pfs" | xargs -I % cp % $RUN_DIR
 		cd $RUN_DIR
-		/usr/local/bin/mkpfi "$BIOS_DIR/all.bin"
-		cat "$GAMEFOLDER/$BASEROMNAME.pfs" | xargs -I  % /usr/local/bin/pfar piece.pfi -a %
+		/usr/bin/mkpfi "$BIOS_DIR/all.bin"
+		cat "$GAMEFOLDER/$BASEROMNAME.pfs" | xargs -I  % /usr/bin/pfar piece.pfi -a %
 	else
 		cp $ROMNAME $RUN_DIR
-		/usr/local/bin/mkpfi "$BIOS_DIR/all.bin"
-		/usr/local/bin/pfar piece.pfi -a "$ROMFILE"
+		/usr/bin/mkpfi "$BIOS_DIR/all.bin"
+		/usr/bin/pfar piece.pfi -a "$ROMFILE"
 		if [[ -f "$GAMEFOLDER/$BASEROMNAME.sav" ]]; then
 			cp "$GAMEFOLDER/$BASEROMNAME.sav" $RUN_DIR
-			/usr/local/bin/pfar piece.pfi -a "$ROMFILE.sav"
+			/usr/bin/pfar piece.pfi -a "$ROMFILE.sav"
 		fi
 	fi
 fi
@@ -47,8 +47,8 @@ if [[ "$EXTENSION" == "pfs" ]]; then
 	cd $GAMEFOLDER
 	xargs -a $ROMNAME cp -t $RUN_DIR
 	cd $RUN_DIR
-	/usr/local/bin/mkpfi "$BIOS_DIR/all.bin"
-	cat $ROMNAME | xargs -I  % /usr/local/bin/pfar piece.pfi -a %
+	/usr/bin/mkpfi "$BIOS_DIR/all.bin"
+	cat $ROMNAME | xargs -I  % /usr/bin/pfar piece.pfi -a %
 fi
 
-/usr/local/bin/piemu
+/usr/bin/piemu

--- a/packages/games/emulators/piemu/package.mk
+++ b/packages/games/emulators/piemu/package.mk
@@ -36,13 +36,13 @@ pre_configure_target() {
 }
 
 makeinstall_target() {
-  mkdir -p ${INSTALL}/usr/local/bin
-  cp ${PKG_BUILD}/.aarch64-libreelec-linux-gnueabi/piemu ${INSTALL}/usr/local/bin
-  chmod 755 ${INSTALL}/usr/local/bin/piemu
-  cp ${PKG_BUILD}/.aarch64-libreelec-linux-gnueabi/tools/mkpfi ${INSTALL}/usr/local/bin
-  chmod 755 ${INSTALL}/usr/local/bin/mkpfi
-  cp ${PKG_BUILD}/.aarch64-libreelec-linux-gnueabi/tools/pfar ${INSTALL}/usr/local/bin
-  chmod 755 ${INSTALL}/usr/local/bin/pfar
-  cp ${PKG_DIR}/bin/piemu.sh ${INSTALL}/usr/local/bin
-  chmod 755 ${INSTALL}/usr/local/bin/piemu.sh
+  mkdir -p ${INSTALL}/usr/bin
+  cp ${PKG_BUILD}/.aarch64-libreelec-linux-gnueabi/piemu ${INSTALL}/usr/bin
+  chmod 755 ${INSTALL}/usr/bin/piemu
+  cp ${PKG_BUILD}/.aarch64-libreelec-linux-gnueabi/tools/mkpfi ${INSTALL}/usr/bin
+  chmod 755 ${INSTALL}/usr/bin/mkpfi
+  cp ${PKG_BUILD}/.aarch64-libreelec-linux-gnueabi/tools/pfar ${INSTALL}/usr/bin
+  chmod 755 ${INSTALL}/usr/bin/pfar
+  cp ${PKG_DIR}/bin/piemu.sh ${INSTALL}/usr/bin
+  chmod 755 ${INSTALL}/usr/bin/piemu.sh
 }


### PR DESCRIPTION
This brings it in line with other emulator startup binaries, and fixes a problem where the runemu.py is failing to launch piemu.