### PR TITLE
Fix ports build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,5 +135,5 @@ docker-image-push:
 
 # Wire up docker to call equivalent make files using % to match and $* to pass the value matched by %
 docker-%:
-	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --init --env-file .env --rm --user $(UID):$(GID) $(DEVELOPER_SETTINGS) -v $(PWD):$(DOCKER_WORK_DIR) -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
+	$(SUDO) $(DOCKER_CMD) run $(PODMAN_ARGS) $(INTERACTIVE) --init --env-file .env --rm --user $(UID):$(GID) $(DEVELOPER_SETTINGS) -v $(PWD):$(DOCKER_WORK_DIR) -v $(HOME)/.cache:$(HOME)/.cache -w $(DOCKER_WORK_DIR) $(DOCKER_IMAGE) $(COMMAND)
 


### PR DESCRIPTION
# Summary
When building after clean - it appears that jinja2 for some reason needs access to the `~/.cache` directory to install a python egg during the `ports` package install (not sure why this didn't happen earlier).  However, in the docker build, we don't actually mount the home directory so the build fails as the directory does not exist.

Ex:
```
pkg_resources.ExtractionError: Can't extract file(s) to egg cache

The following error occurred while trying to extract file(s)
to the Python egg cache:

  [Errno 13] Permission denied: '/home/build/.cache'

The Python egg cache directory is currently set to:

  /home/build/.cache/Python-Eggs

Perhaps your account does not have write access to this directory?
You can change the cache directory by setting the PYTHON_EGG_CACHE
environment variable to point to an accessible directory.

FAILURE: scripts/install ports has failed!
[400/420] [FAIL] install ports
```


# Fix
This just mounts the ~/.cache directory into the docker container and it should be created if it does not exist.  I'm not sure this is the 'right' fix (we probably should update the cache location or something so build doesn't update ~/.cache at all), but this works for now to get build moving.  I applied this temporarily on the build server for the RG351P build to test.