### PR TITLE
Fix issue: RG552 switches back between two different IP addresses.

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -77,7 +77,7 @@ post_makeinstall_target() {
         -e "s|^# AllowHostnameUpdates.*|AllowHostnameUpdates = false|g" \
         -e "s|^# PersistentTetheringMode.*|PersistentTetheringMode = true|g" \
         -e "s|^# SingleConnectedTechnology.*|SingleConnectedTechnology = true|g" \
-        -e "s|^# NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb|NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb,docker,veth,zt|g"
+        -e "s|^# NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb|NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb,docker,veth,zt,p2p|g"
 
   mkdir -p $INSTALL/usr/share/connman/
     cp $PKG_DIR/config/settings $INSTALL/usr/share/connman/


### PR DESCRIPTION
# Summary of Issue
IP address on the RG552 appears to switch between two IP addresses periodically.  Accessing ssh, etc, via IP address is a pain as it will keep switching.  Exactly when it switches back and forth and which IP stays active seems somewhat random (sometimes will stay same for days and then switch, etc).

# Root Cause
I believe the issue as to why the 552 has two wifi connections (which sometimes get different IP addresses) is as follows:
- connman for some reason detects the network device: `p2p0` (wifi direct) as normal wifi. This is shown in the logs of connman.
- connman has p2p disabled, but since p2p0 is detected as wifi - connman still uses it.  
- Since there are two devices detected as wifi (p2p0 and wlan0), it is someone random which is chosen.  Many wifi routers will then assign different IP's to each (even though the MAC is effectively the same - there is somehow a different identifier for p2p0)
  - connman also has a setting to ensure only **one** IP address is active at a time which we are using - so perhaps it's not totally random which device is chosen, but switchover happens when connectivity is poor, etc.  Not 100% sure here, but at least on my wifi I see it switching back and forth periodically.

# Testing
You can test if you have the issue by seeing what interface your IP address is on. I believe we should never be assigning an IP address to p2p0 (but before this fix, you will get one quite often).  After fix - IP will always be assigned to wlan0. Ex:
```
~ # ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP8000> mtu 1500 qdisc mq qlen 1000
    link/ether 54:ef:33:71:8c:52 brd ff:ff:ff:ff:ff:ff
    inet 10.10.0.13/24 brd 10.10.0.255 scope global wlan0
       valid_lft forever preferred_lft forever
    inet6 fe80::56ef:33ff:fe71:8c52/64 scope link 
       valid_lft forever preferred_lft forever
3: p2p0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop qlen 1000
    link/ether 56:ef:33:71:8c:52 brd ff:ff:ff:ff:ff:ff
```
# Fix 
The fix is to tell connman to **not** use `p2p*` interfaces through the `NetworkInterfaceBlacklist` parameter.

I believe this should be fine/low risk as connman already disables p2p technology and I do not believe it's our intention to use p2p/wifi direct.  For example, it's not like wifi hotspot/wifi direct is really supported nor makes sense as a use case for 351ELEC at least in the near term.

# User impact
The IP address did seem to default to the `p2p0` IP for me - so it may appear that the DHCP IP address of the 552 changes after updating to this code.