### PR TITLE
freej2me: Add patch to work around RecordStore saving to the working directory instead of the save dirtectory as expected

### DIFF
--- a/packages/games/libretro/freej2me/patches/recordstore_location.patch
+++ b/packages/games/libretro/freej2me/patches/recordstore_location.patch
@@ -1,0 +1,15 @@
+diff --git a/src/javax/microedition/rms/RecordStore.java b/src/javax/microedition/rms/RecordStore.java
+index ff9fccd..1ba2077 100644
+--- a/src/javax/microedition/rms/RecordStore.java
++++ b/src/javax/microedition/rms/RecordStore.java
+@@ -70,8 +70,8 @@ public class RecordStore
+ 
+ 		appname = Mobile.getPlatform().loader.suitename;
+ 
+-		rmsPath = "rms/"+appname;
+-		rmsFile = "rms/"+appname+"/"+recordStoreName;
++		rmsPath = "/roms/j2me/rms/"+appname;
++		rmsFile = "/roms/j2me/rms/"+appname+"/"+recordStoreName;
+ 
+ 		try
+ 		{


### PR DESCRIPTION
The "rms" directory is being saved to the current working directory (which for EmulationStation is /), which isn't writeable, so it doesn't get created when freej2me is launched via EmulationStation (but it does work if RetroArch + the core is launched from ssh). This just hardcodes it to go to /roms/j2me for now, which is where we expect saves to be.

This makes Doom RPG, Wolfenstein RPG, etc work properly.