### PR TITLE
Remove `mkfs.exfat` file in 'exfatprogs' to avoid conflicts with same file in 'exfat' package

### DIFF
--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -11,3 +11,10 @@ PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain linux"
 PKG_LONGDESC="Userspace utilities for exfat"
 PKG_TOOLCHAIN="autotools"
+
+# 'mkfs.exfat' exists in the 'exfat' package and that is what ends up in the final 351ELEC image
+# In some cases, there is an error condition copying this file over the symlink from the 'exfat' package
+# Removing the mkfs.exfat file just avoids that entirely
+post_makeinstall_target() {
+  rm -rf "${INSTALL}/usr/sbin/mkfs.exfat"
+}


### PR DESCRIPTION
# Summary
 - 'mkfs.exfat' exists in the 'exfat' package and that is what ends up in the final 351ELEC image.
 - In some cases, there is an error condition copying this file over the symlink from the 'exfat' package
 - Removing the mkfs.exfat from the `exfatprogs` package should avoid that copy entirely and avoid the error.

# Details
The following error is sometimes seen in builds.
```
cp: not writing through dangling symlink '/work/build.351ELEC-RG351P.aarch64/image/system/usr/sbin/mkfs.exfat'
FAILURE: scripts/install exfatprogs has failed!
```

I'm not 100% sure why it only happens sometimes (and why mostly on the build server - and then mostly after I switched to btrfs a few months ago), but  - disregarding how we get in this situation only sometimes...  It appears the actual error is because both the 'exfat' and the 'exfatprogs' package include mkfs.exfat and one is a link.  So if the link ends up in a state where it doesn't point to something, the copy of the file to overwrite it will blow up (cp doesn't overwrite dangling links).

Ex - the files from the different packages for reference
```
: lrwxrwxrwx 1 build build   9 Mar  1 00:26 ./exfat-66747e2df0771b23ea30cbef3767f2b72488e914/.install_pkg/usr/sbin/mkfs.exfat -> mkexfatfs
-rwxr-xr-x 1 build build 76K Mar  1 06:12 ./exfatprogs-7c3b61769bb04eaafedf245db396813bbcfb2b0a/.aarch64-libreelec-linux-gnueabi/mkfs/mkfs.exfat
-rwxr-xr-x 1 build build 67K Mar  1 06:12 ./exfatprogs-7c3b61769bb04eaafedf245db396813bbcfb2b0a/.install_pkg/usr/sbin/mkfs.exfat
lrwxrwxrwx 1 build build   9 Mar 13 01:15 ./image/system/usr/sbin/mkfs.exfat -> mkexfatfs
```
Given that the link from the `exfat` package is what is supposed to end up in the image (or at least what is in pineapple forrest and other releases), I can just remove the `mkfs.exfat` file at the end of the extfatprogs which should avoid the situation.