### PR TITLE
Slim down retorarch assets (remove new unneeded themes)

### DIFF
--- a/packages/351elec/package.mk
+++ b/packages/351elec/package.mk
@@ -98,7 +98,7 @@ makeinstall_target() {
 
 post_install() {
 # Remove unnecesary Retroarch Assets and overlays
-  for i in branding nuklear nxrgui pkg switch wallpapers zarch COPYING; do
+  for i in FlatUX Automatic Systematic branding nuklear nxrgui pkg switch wallpapers zarch COPYING; do
     rm -rf "$INSTALL/usr/share/retroarch-assets/$i"
   done
 


### PR DESCRIPTION
The last bump of retroarch-assets included about 200mb of extra files.  This just removes those as they are unneeded.